### PR TITLE
Default org

### DIFF
--- a/sql/migrations/000002_insert_organization_default.sql
+++ b/sql/migrations/000002_insert_organization_default.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+INSERT INTO organizations (
+    organization_id,
+    created_at,
+    updated_at,
+    name,
+    email,
+    session_remember,
+    session_timeout
+) VALUES (
+    'org-YYzEOzuSw4HjH8CW',
+    now(),
+    now(),
+    'default',
+    'admin@example.org',
+    20160,
+    20160
+);
+
+-- +goose Down
+DELETE
+FROM organizations
+WHERE organization_id = 'org-YYzEOzuSw4HjH8CW';


### PR DESCRIPTION
Pre-configure oTF with a default organization, `default`, to save the user from having to create one.