### PR TITLE
Set min supported terraform version (1.2.0)

### DIFF
--- a/agent/environment.go
+++ b/agent/environment.go
@@ -78,11 +78,11 @@ func NewEnvironment(
 		return nil, errors.Wrap(err, "retrieving workspace")
 	}
 
-	// create token for terraform for it to authenticate with the otf registry
-	// when retrieving modules and providers
+	// Create token for terraform for it to authenticate with the otf registry
+	// when retrieving modules and providers, and make it available to terraform
+	// via an environment variable.
 	//
-	// TODO: TF_TOKEN_* environment variables are only supported from terraform
-	// v1.20 onwards. We should set that as the min version for use with otf.
+	// NOTE: environment variable support is only available in terraform >= 1.2.0
 	session, err := app.CreateRegistrySession(ctx, ws.Organization())
 	if err != nil {
 		return nil, errors.Wrap(err, "creating registry session")

--- a/e2e/tasks.go
+++ b/e2e/tasks.go
@@ -103,17 +103,17 @@ func terraformLoginTasks(t *testing.T, hostname string) chromedp.Tasks {
 	return []chromedp.Action{
 		// go to profile
 		chromedp.Click("#top-right-profile-link > a", chromedp.NodeVisible),
-		chromedp.WaitReady(`body`),
+		screenshot(t),
 		// go to tokens
 		chromedp.Click("#user-tokens-link > a", chromedp.NodeVisible),
-		chromedp.WaitReady(`body`),
+		screenshot(t),
 		// create new token
 		chromedp.Click("#new-user-token-button", chromedp.NodeVisible),
-		chromedp.WaitReady(`body`),
+		screenshot(t),
 		chromedp.Focus("#description", chromedp.NodeVisible),
 		input.InsertText("e2e-test"),
 		chromedp.Submit("#description"),
-		chromedp.WaitReady(`body`),
+		screenshot(t),
 		// capture token
 		chromedp.Text(".flash-success > .data", &token, chromedp.NodeVisible),
 		// pass token to terraform login

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package otf
 
 import (
 	"errors"
+	"fmt"
 )
 
 // Generic errors applicable to all resources.
@@ -36,6 +37,10 @@ var (
 	// ErrInvalidTerraformVersion is returned when a terraform version string is
 	// not a semantic version string (major.minor.patch).
 	ErrInvalidTerraformVersion = errors.New("invalid terraform version")
+
+	// ErrUnsupportedTerraformVersion is returned when a terraform version is
+	// not supported.
+	ErrUnsupportedTerraformVersion = fmt.Errorf("only terraform versions >= %s are supported", MinTerraformVersion)
 
 	// ErrInvalidWorkspaceID is returned when the workspace ID is invalid.
 	ErrInvalidWorkspaceID = errors.New("invalid value for workspace ID")

--- a/hack/go-tfe-tests.bash
+++ b/hack/go-tfe-tests.bash
@@ -43,7 +43,7 @@ function cleanup()
         cat $logfile
     fi
 }
-trap cleanup EXIT ERR
+trap cleanup EXIT
 
 # wait for otfd to listen on port and capture port number
 tries=0

--- a/http/html/static/css/main.css
+++ b/http/html/static/css/main.css
@@ -251,6 +251,10 @@ table.variables tbody tr {
   gap: 1em;
 }
 
+input:invalid {
+  background-color: lightpink;
+}
+
 /* Free-form inputs need to accommodate more text */
 input.freeform {
   width: 30em;

--- a/http/html/static/templates/content/workspace_edit.tmpl
+++ b/http/html/static/templates/content/workspace_edit.tmpl
@@ -53,7 +53,7 @@
     </div>
     <div class="field">
       <label for="terraform_version">Terraform Version</label>
-      <input type="text" name="terraform_version" id="terraform_version" value="{{ .Content.TerraformVersion }}" required>
+      <input type="text" name="terraform_version" id="terraform_version" value="{{ .Content.TerraformVersion }}" required pattern="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$">
     </div>
     <div class="field">
       <button>Save changes</button>

--- a/otf.go
+++ b/otf.go
@@ -27,11 +27,13 @@ const (
 	ChunkEndMarker = byte(3)
 )
 
-// A regular expression used to validate common string ID patterns.
-var reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-\._]+$`)
+var (
+	// A regular expression used to validate common string ID patterns.
+	reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-\._]+$`)
 
-// A regular expression used to validate semantic versions (major.minor.patch).
-var reSemanticVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	// A regular expression used to validate semantic versions (major.minor.patch).
+	reSemanticVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+)
 
 // Application provides access to the otf application services
 type Application interface {

--- a/workspace.go
+++ b/workspace.go
@@ -6,12 +6,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/leg100/otf/semver"
 )
 
 const (
 	DefaultAllowDestroyPlan    = true
 	DefaultFileTriggersEnabled = true
-	DefaultTerraformVersion    = "1.3.7"
+
+	MinTerraformVersion     = "1.2.0"
+	DefaultTerraformVersion = "1.3.7"
 
 	RemoteExecutionMode ExecutionMode = "remote"
 	LocalExecutionMode  ExecutionMode = "local"
@@ -223,6 +226,9 @@ func (ws *Workspace) setExecutionMode(m ExecutionMode) error {
 func (ws *Workspace) setTerraformVersion(v string) error {
 	if !validSemanticVersion(v) {
 		return ErrInvalidTerraformVersion
+	}
+	if result := semver.Compare(v, MinTerraformVersion); result < 0 {
+		return ErrUnsupportedTerraformVersion
 	}
 	ws.terraformVersion = v
 	return nil

--- a/workspace_factory_test.go
+++ b/workspace_factory_test.go
@@ -50,6 +50,15 @@ func TestNewWorkspace(t *testing.T) {
 			},
 			want: ErrInvalidTerraformVersion,
 		},
+		{
+			name: "unsupported terraform version",
+			opts: CreateWorkspaceOptions{
+				Name:             String("my-workspace"),
+				Organization:     String("my-org"),
+				TerraformVersion: String("0.14.0"),
+			},
+			want: ErrUnsupportedTerraformVersion,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
OTF relies on at least one feature that is only supported in version 1.2.0 of terraform and higher: setting credentials in TF_TOKEN_* environment variables.

Setting a relatively recent version as the minimum also makes it easier to develop and test OTF.