### PR TITLE
Terraform lock file is optional

### DIFF
--- a/e2e/lock_file_test.go
+++ b/e2e/lock_file_test.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/chromedp/chromedp"
+	"github.com/google/uuid"
+	"github.com/leg100/otf/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLockFile tests various scenarios relating to the dependency lock file
+// (.terraform.lock.hcl). Users may upload one, they may not, they may upload
+// one with hashes for a different OS (e.g. Mac) and OTF is running on linux and
+// has to then generates hashes for linux, etc. It is notorious for causing
+// difficulties for users and it's no different for OTF.
+func TestLockFile(t *testing.T) {
+	addBuildsToPath(t)
+
+	org := uuid.NewString()
+	user := cloud.User{
+		Name:          uuid.NewString(),
+		Teams:         []cloud.Team{{"owners", org}},
+		Organizations: []string{org},
+	}
+
+	daemon := &daemon{}
+	daemon.withGithubUser(&user)
+	hostname := daemon.start(t)
+	workspaceName := t.Name()
+
+	// create browser
+	ctx, cancel := chromedp.NewContext(allocator)
+	defer cancel()
+
+	// login, create workspace and set working directory
+	err := chromedp.Run(ctx, chromedp.Tasks{
+		githubLoginTasks(t, hostname, user.Name),
+		createWorkspaceTasks(t, hostname, org, workspaceName),
+	})
+	require.NoError(t, err)
+
+	// create root module with only a variable and no resources - this should
+	// result in *no* lock file being created.
+	root := t.TempDir()
+	config := []byte(fmt.Sprintf(`
+terraform {
+  backend "remote" {
+	hostname = "%s"
+	organization = "%s"
+
+	workspaces {
+	  name = "%s"
+	}
+  }
+}
+
+variable "foo" {
+	default = "bar"
+}
+`, hostname, org, workspaceName))
+	err = os.WriteFile(filepath.Join(root, "main.tf"), []byte(config), 0o600)
+	require.NoError(t, err)
+
+	// ensure tf cli has a token
+	err = chromedp.Run(ctx, terraformLoginTasks(t, hostname))
+	require.NoError(t, err)
+
+	// verify terraform init and plan run without error
+	cmd := exec.Command("terraform", "init", "-no-color")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	t.Log(string(out))
+	require.NoError(t, err)
+
+	cmd = exec.Command("terraform", "plan", "-no-color")
+	cmd.Dir = root
+	out, err = cmd.CombinedOutput()
+	t.Log(string(out))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
If user has not uploaded a lock file then OTF produces an error

```
Error: reading lock file: open /tmp/otf-config-65329753/subdir/.terraform.lock.hcl: no such file or directory
```

But there are legitimate cases in which a user may not upload a lock file, e.g. no resources but only variables.