### PR TITLE
Add support for attaching a VCS in CreateWorkspace

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -76,7 +76,7 @@ func newChildApp(parent *Application, opts Options, db otf.DB) *Application {
 		cache:               opts.Cache,
 		PubSubService:       opts.PubSub,
 		Service:             opts.CloudService,
-		Authorizer:          opts.Authorizer,
+		Authorizer:          otf.NewAuthorizer(opts.Logger, db),
 		StateVersionService: opts.StateVersionService,
 		RunFactory:          parent.RunFactory,
 		proxy:               parent.proxy,

--- a/http/workspace.go
+++ b/http/workspace.go
@@ -136,7 +136,21 @@ func (s *Server) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := s.Application.CreateWorkspace(r.Context(), otf.CreateWorkspaceOptions{
+	var repo *otf.WorkspaceRepo
+	if opts.VCSRepo != nil {
+		repo = new(otf.WorkspaceRepo)
+		if identifier := opts.VCSRepo.Identifier; identifier != nil {
+			repo.Identifier = *identifier
+		}
+		if branch := opts.VCSRepo.Branch; branch != nil {
+			repo.Branch = *branch
+		}
+		if providerID := opts.VCSRepo.OAuthTokenID; providerID != nil {
+			repo.ProviderID = *providerID
+		}
+	}
+
+	ws, err := otf.CreateWorkspace(r.Context(), s.Application, otf.CreateWorkspaceOptions{
 		AllowDestroyPlan:           opts.AllowDestroyPlan,
 		AutoApply:                  opts.AutoApply,
 		Description:                opts.Description,
@@ -154,6 +168,7 @@ func (s *Server) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		TerraformVersion:           opts.TerraformVersion,
 		TriggerPrefixes:            opts.TriggerPrefixes,
 		WorkingDirectory:           opts.WorkingDirectory,
+		Repo:                       repo,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, err)

--- a/sql/workspace.go
+++ b/sql/workspace.go
@@ -38,17 +38,7 @@ func (db *DB) CreateWorkspace(ctx context.Context, ws *otf.Workspace) error {
 		if err != nil {
 			return Error(err)
 		}
-		if ws.Repo() != nil {
-			_, err = tx.InsertWorkspaceRepo(ctx, pggen.InsertWorkspaceRepoParams{
-				Branch:        String(ws.Repo().Branch),
-				WebhookID:     UUID(ws.Repo().WebhookID),
-				VCSProviderID: String(ws.Repo().ProviderID),
-				WorkspaceID:   String(ws.ID()),
-			})
-			if err != nil {
-				return Error(err)
-			}
-		}
+
 		return nil
 	})
 	if err != nil {

--- a/workspace.go
+++ b/workspace.go
@@ -2,12 +2,12 @@ package otf
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/leg100/otf/rbac"
 	"github.com/leg100/otf/semver"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -342,6 +342,40 @@ type WorkspaceStore interface {
 	WorkspaceLockService
 	CurrentRunService
 	WorkspacePermissionService
+}
+
+func CreateWorkspace(ctx context.Context, app Application, opts CreateWorkspaceOptions) (*Workspace, error) {
+	var (
+		ws  *Workspace
+		err error
+	)
+
+	err = app.Tx(ctx, func(a Application) error {
+		// First create the workspace.
+		ws, err = a.CreateWorkspace(ctx, opts)
+		if err != nil {
+			return err
+		}
+
+		// If needed, connect the VCS repository.
+		if repo := opts.Repo; repo != nil {
+			err = a.ConnectWorkspace(ctx, ws.ID(), ConnectWorkspaceOptions{
+				ProviderID: repo.ProviderID,
+				Identifier: repo.Identifier,
+				Branch:     repo.Branch,
+			})
+			if err != nil {
+				return errors.Wrap(err, "connecting workspace")
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ws, nil
 }
 
 // CurrentRunService provides interaction with the current run for a workspace,

--- a/workspace_connector.go
+++ b/workspace_connector.go
@@ -14,5 +14,6 @@ type WorkspaceConnector interface {
 type ConnectWorkspaceOptions struct {
 	Identifier string `schema:"identifier,required"` // repo id: <owner>/<repo>
 	ProviderID string `schema:"vcs_provider_id,required"`
+	Branch     string // branch of the VCS
 	Cloud      string // cloud host of the repo
 }


### PR DESCRIPTION
- Introduce the function CreateWorkspace that creates both the workspace resource and potentially tries to connect it immediately (inside a transaction) if a repository was provided.
- Fixed newChildApp to make the Authorizer use the transaction.
- Added support to specify a branch for the repository.