### PR TITLE
Team name is mandatory

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -97,9 +97,12 @@ func (g *Client) GetUser(ctx context.Context) (*cloud.User, error) {
 		}
 	}
 
+	// Convert each github team to a cloud team. Use the github slug rather than
+	// the github name because the latter often contains whitespace, and OTF
+	// names should not contain whitespace.
 	for _, gteam := range gteams {
 		user.Teams = append(user.Teams, cloud.Team{
-			Name:         gteam.GetName(),
+			Name:         gteam.GetSlug(),
 			Organization: gteam.GetOrganization().GetLogin(),
 		})
 	}

--- a/github/test_server.go
+++ b/github/test_server.go
@@ -97,7 +97,7 @@ func NewTestServer(t *testing.T, opts ...TestServerOption) *TestServer {
 			var teams []*github.Team
 			for _, team := range srv.user.Teams {
 				teams = append(teams, &github.Team{
-					Name: otf.String(team.Name),
+					Slug: otf.String(team.Name),
 					Organization: &github.Organization{
 						Login: otf.String(team.Organization),
 					},

--- a/sql/migrations/20230224094530_add_team_name_constraint_not_null.sql
+++ b/sql/migrations/20230224094530_add_team_name_constraint_not_null.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE teams
+    ALTER COLUMN name SET NOT NULL,
+    ADD CONSTRAINT team_name_uniq UNIQUE(organization_name, name)
+;
+
+-- +goose Down
+ALTER TABLE teams
+    ALTER COLUMN name DROP NOT NULL,
+    DROP CONSTRAINT team_name_uniq
+;

--- a/sql/team_test.go
+++ b/sql/team_test.go
@@ -19,6 +19,12 @@ func TestTeam_Create(t *testing.T) {
 
 	err := db.CreateTeam(ctx, team)
 	require.NoError(t, err)
+
+	t.Run("duplicate name", func(t *testing.T) {
+		dup := otf.NewTeam("team-awesome", org)
+		err := db.CreateTeam(ctx, dup)
+		require.Equal(t, otf.ErrResourceAlreadyExists, err)
+	})
 }
 
 func TestTeam_Update_ByID(t *testing.T) {


### PR DESCRIPTION
...also, for github team synchronisation, we've been using the github team name, which often contains whitespace and mixed capitalization, whereas in OTF, we should not be using either for names anywhere (OTF names *are* slugs, and vice-versa). Therefore, use the github team *slug* for synchronisation instead.