### PR TITLE
Bump go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/leg100/otf
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2


### PR DESCRIPTION
Would like to use the new 1.20 feature that permits wrapping multiple errors.