### PR TITLE
Add support for _FILE env vars

### DIFF
--- a/cmd/environment_variables.go
+++ b/cmd/environment_variables.go
@@ -27,8 +27,7 @@ func SetFlagsFromEnvVariables(fs *pflag.FlagSet) {
 			return
 		}
 
-		val, present := os.LookupEnv(envVar + "_FILE")
-		if present {
+		if val, present := os.LookupEnv(envVar + "_FILE"); present {
 			value, err := os.ReadFile(val)
 			if err != nil {
 				PrintError(errors.Wrapf(err, "failed to read file %s", envVar+"_FILE"))

--- a/cmd/otf-agent/main.go
+++ b/cmd/otf-agent/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/leg100/otf/client"
 	cmdutil "github.com/leg100/otf/cmd"
 	"github.com/leg100/otf/http"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -80,7 +81,9 @@ func run(ctx context.Context, args []string) error {
 	// otfd.
 	cfg.External = true
 
-	cmdutil.SetFlagsFromEnvVariables(cmd.Flags())
+	if err = cmdutil.SetFlagsFromEnvVariables(cmd.Flags()); err != nil {
+		return errors.Wrap(err, "failed to populate config from environment vars")
+	}
 
 	return cmd.ExecuteContext(ctx)
 }

--- a/cmd/otf/app.go
+++ b/cmd/otf/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/leg100/otf/client"
 	cmdutil "github.com/leg100/otf/cmd"
 	"github.com/leg100/otf/http"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -45,10 +46,9 @@ func (a *application) run(ctx context.Context, args []string, out io.Writer) err
 	cmd.AddCommand(a.runCommand())
 	cmd.AddCommand(a.agentCommand())
 
-	cmdutil.SetFlagsFromEnvVariables(cmd.Flags())
-
-	if err := cmd.ExecuteContext(ctx); err != nil {
-		return err
+	if err = cmdutil.SetFlagsFromEnvVariables(cmd.Flags()); err != nil {
+		return errors.Wrap(err, "failed to populate config from environment vars")
 	}
-	return nil
+
+	return cmd.ExecuteContext(ctx)
 }

--- a/cmd/otfd/main.go
+++ b/cmd/otfd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/leg100/otf/sql"
 	"github.com/leg100/otf/state"
 	"github.com/leg100/otf/variable"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
@@ -68,7 +69,9 @@ func run(ctx context.Context, args []string, out io.Writer) error {
 	cmd.Flags().StringVar(&d.database, "database", DefaultDatabase, "Postgres connection string")
 	cmd.Flags().StringVar(&d.hostname, "hostname", "", "User-facing hostname for otf")
 
-	cmdutil.SetFlagsFromEnvVariables(cmd.Flags())
+	if err := cmdutil.SetFlagsFromEnvVariables(cmd.Flags()); err != nil {
+		return errors.Wrap(err, "failed to populate config from environment vars")
+	}
 
 	cmd.SetArgs(args)
 	return cmd.ExecuteContext(ctx)

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,6 +201,17 @@ helm show values otf/otf
 !!! note
     The helm chart is maintained in a separate [github repo](https://github.com/leg100/otf-charts).
 
+### Configuration from env vars
+
+OTF can be configured from environment variables. Arguments can be converted to the equivalent env var by prefixing
+it with `OTF_`, replacing all `-` with `_`, and upper-casing it. For example:
+
+- `--secret` becomes `OTF_SECRET`
+- `--site-token` becomes `OTF_SITE_TOKEN`
+
+Env variables can be suffixed with `_FILE` to tell otf to read the values from a file. This is useful for container
+environments where secrets are often mounted as files.
+
 ## Authentication
 
 Users sign into OTF primarily via an SSO provider. Support currently exists for:


### PR DESCRIPTION
This PR adds support for env vars suffixed with `_FILE`. This allows for one to set e.g. `OTF_SECRET_FILE` to a file path, which OTF will read, and assign it to the `--secret` argument.

This is useful for some container environments where secrets can only be mounted and are expected to be read by the application itself. This is also more secure, as env vars are trivial to be read by anyone who has access to the host. This way, files can be permissioned, and the values can be only known by the user running the application, and thus the application itself.

I've also added some docs to explain this, as I had to dig into the code to see that env var configuration is supported.