### PR TITLE
Fix session level advisory locks

### DIFF
--- a/otf.go
+++ b/otf.go
@@ -50,16 +50,14 @@ type DB interface {
 	Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error)
 	// Send batches of SQL queries over the wire.
 	SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults
+	// Wait for a session-level advisory lock to become available.
+	WaitAndLock(ctx context.Context, id int64, fn func() error) error
 
 	pggen.Querier // queries generated from SQL
 	Close()       // Close all connections in pool
 
 	// additional queries that wrap the generated queries
 	GetLogs(ctx context.Context, runID string, phase PhaseType) ([]byte, error)
-}
-
-type DatabaseLock interface {
-	Release()
 }
 
 // GetID retrieves the ID field of a struct contained in s. If s is not a struct,

--- a/sql/db_test.go
+++ b/sql/db_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,5 +25,21 @@ func TestSetDefaultMaxConnections(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestWaitAndLock tests acquiring a connection from a pool, obtaining a session
+// lock and then releasing lock and the connection, and it does this several
+// times, to demonstrate that it is returning resources and not running into
+// limits.
+func TestWaitAndLock(t *testing.T) {
+	ctx := context.Background()
+	db, _ := NewTestDB(t)
+
+	for i := 0; i < 100; i++ {
+		func() {
+			err := db.WaitAndLock(ctx, 123, func() error { return nil })
+			require.NoError(t, err)
+		}()
 	}
 }


### PR DESCRIPTION
If the run scheduler restarts (as a result of an error, which can happen as part of the normal flow, particularly in integration tests), then it should release the session-level advisory lock it holds in postgres. However, it was not doing that and as a result when it restarted it could not re-obtain the lock.

(This bug *might* be the cause of #334 and #338, although in both cases it doesn't seem like the scheduler was being restarted, otherwise the logs would have reported that quite clearly).