### PR TITLE
Respond with an appropriate http status code

### DIFF
--- a/auth/api.go
+++ b/auth/api.go
@@ -43,13 +43,13 @@ func (h *api) addHandlers(r *mux.Router) {
 func (h *api) createUser(w http.ResponseWriter, r *http.Request) {
 	var params jsonapi.CreateUserOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &params); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	user, err := h.svc.CreateUser(r.Context(), *params.Username)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -59,12 +59,12 @@ func (h *api) createUser(w http.ResponseWriter, r *http.Request) {
 func (h *api) deleteUser(w http.ResponseWriter, r *http.Request) {
 	username, err := decode.Param("username", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	if err := h.svc.DeleteUser(r.Context(), username); err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -74,7 +74,7 @@ func (h *api) deleteUser(w http.ResponseWriter, r *http.Request) {
 func (h *api) addTeamMembership(w http.ResponseWriter, r *http.Request) {
 	var params TeamMembershipOptions
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *api) addTeamMembership(w http.ResponseWriter, r *http.Request) {
 func (h *api) removeTeamMembership(w http.ResponseWriter, r *http.Request) {
 	var params TeamMembershipOptions
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -115,11 +115,11 @@ func (h *api) getCurrentUser(w http.ResponseWriter, r *http.Request) {
 func (h *api) createTeam(w http.ResponseWriter, r *http.Request) {
 	var params jsonapi.CreateTeamOptions
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	if err := jsonapi.UnmarshalPayload(r.Body, &params); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -128,7 +128,7 @@ func (h *api) createTeam(w http.ResponseWriter, r *http.Request) {
 		Organization: *params.Organization,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -143,13 +143,13 @@ func (h *api) getTeam(w http.ResponseWriter, r *http.Request) {
 		Name         *string `schema:"team_name,required"`
 	}
 	if err := decode.All(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	team, err := h.svc.GetTeam(r.Context(), *params.Organization, *params.Name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -159,12 +159,12 @@ func (h *api) getTeam(w http.ResponseWriter, r *http.Request) {
 func (h *api) deleteTeam(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("team_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	if err := h.svc.DeleteTeam(r.Context(), id); err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (h *api) deleteTeam(w http.ResponseWriter, r *http.Request) {
 func (h *api) createRegistrySession(w http.ResponseWriter, r *http.Request) {
 	var opts jsonapi.RegistrySessionCreateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -184,7 +184,7 @@ func (h *api) createRegistrySession(w http.ResponseWriter, r *http.Request) {
 		Organization: opts.Organization,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -199,7 +199,7 @@ func (h *api) createRegistrySession(w http.ResponseWriter, r *http.Request) {
 func (h *api) createAgentToken(w http.ResponseWriter, r *http.Request) {
 	var opts jsonapi.AgentTokenCreateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	at, err := h.svc.CreateAgentToken(r.Context(), CreateAgentTokenOptions{
@@ -207,7 +207,7 @@ func (h *api) createAgentToken(w http.ResponseWriter, r *http.Request) {
 		Organization: opts.Organization,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	jsonapi.WriteResponse(w, r, &jsonapi.AgentToken{
@@ -220,7 +220,7 @@ func (h *api) createAgentToken(w http.ResponseWriter, r *http.Request) {
 func (h *api) getCurrentAgent(w http.ResponseWriter, r *http.Request) {
 	at, err := agentFromContext(r.Context())
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	jsonapi.WriteResponse(w, r, &jsonapi.AgentToken{

--- a/auth/user_db.go
+++ b/auth/user_db.go
@@ -19,12 +19,12 @@ func (db *pgdb) CreateUser(ctx context.Context, user *User) error {
 			UpdatedAt: sql.Timestamptz(user.UpdatedAt),
 		})
 		if err != nil {
-			return err
+			return sql.Error(err)
 		}
 		for _, team := range user.Teams {
 			_, err = tx.InsertTeamMembership(ctx, sql.String(user.Username), sql.String(team.ID))
 			if err != nil {
-				return err
+				return sql.Error(err)
 			}
 		}
 		return nil

--- a/configversion/jsonapi_marshaler.go
+++ b/configversion/jsonapi_marshaler.go
@@ -44,7 +44,7 @@ func (m *jsonapiMarshaler) toConfigurationVersion(from *ConfigurationVersion) (*
 
 func (m *jsonapiMarshaler) toList(from *ConfigurationVersionList) (*jsonapi.ConfigurationVersionList, error) {
 	to := &jsonapi.ConfigurationVersionList{
-		Pagination: from.Pagination.ToJSONAPI(),
+		Pagination: jsonapi.NewPagination(from.Pagination),
 	}
 	for _, i := range from.Items {
 		cv, err := m.toConfigurationVersion(i)

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// Generic errors applicable to all resources.
+// Generic errors
 var (
 	// ErrAccessNotPermitted is returned when an authorization check fails.
 	ErrAccessNotPermitted = errors.New("access to the resource is not permitted")
@@ -14,6 +14,9 @@ var (
 
 	// ErrResourceNotFound is returned when a receiving a 404.
 	ErrResourceNotFound = errors.New("resource not found")
+
+	// ErrMissingParameter is returned when a required parameter is missing
+	ErrMissingParameter = errors.New("missing required parameter")
 
 	// ErrResourceAlreadyExists is returned when attempting to create a resource
 	// that already exists.
@@ -32,6 +35,10 @@ var (
 
 	// ErrWarning is a non-fatal error
 	ErrWarning = errors.New("warning")
+
+	// ErrUploadTooLarge is returned when a user attempts to upload data that
+	// is too large.
+	ErrUploadTooLarge = errors.New("upload is too large")
 )
 
 // Resource Errors
@@ -57,4 +64,21 @@ var (
 	ErrStatusTimestampNotFound = errors.New("corresponding status timestamp not found")
 
 	ErrInvalidRepo = errors.New("repository path is invalid")
+)
+
+// Workspace errors
+var (
+	ErrWorkspaceAlreadyLocked         = errors.New("workspace already locked")
+	ErrWorkspaceLockedByDifferentUser = errors.New("workspace locked by different user")
+	ErrWorkspaceAlreadyUnlocked       = errors.New("workspace already unlocked")
+	ErrWorkspaceUnlockDenied          = errors.New("unauthorized to unlock workspace")
+	ErrWorkspaceInvalidLock           = errors.New("invalid workspace lock")
+	ErrUnsupportedTerraformVersion    = errors.New("unsupported terraform version")
+)
+
+// Run errors
+var (
+	ErrRunDiscardNotAllowed     = errors.New("run was not paused for confirmation or priority; discard not allowed")
+	ErrRunCancelNotAllowed      = errors.New("run was not planning or applying; cancel not allowed")
+	ErrRunForceCancelNotAllowed = errors.New("run was not planning or applying, has not been canceled non-forcefully, or the cool-off period has not yet passed")
 )

--- a/http/jsonapi/errors.go
+++ b/http/jsonapi/errors.go
@@ -5,10 +5,33 @@ import (
 	"strconv"
 
 	"github.com/leg100/jsonapi"
+	"github.com/leg100/otf"
 )
 
-// Error writes an HTTP response with a JSON-API marshalled error obj.
-func Error(w http.ResponseWriter, code int, err error) {
+var codes = map[error]int{
+	otf.ErrResourceNotFound:         http.StatusNotFound,
+	otf.ErrResourceAlreadyExists:    http.StatusConflict,
+	otf.ErrMissingParameter:         http.StatusUnprocessableEntity,
+	otf.ErrUploadTooLarge:           http.StatusUnprocessableEntity,
+	otf.ErrWorkspaceAlreadyLocked:   http.StatusConflict,
+	otf.ErrWorkspaceAlreadyUnlocked: http.StatusConflict,
+	otf.ErrRunDiscardNotAllowed:     http.StatusConflict,
+	otf.ErrRunCancelNotAllowed:      http.StatusConflict,
+	otf.ErrRunForceCancelNotAllowed: http.StatusConflict,
+}
+
+func lookupHTTPCode(err error) int {
+	if v, ok := codes[err]; ok {
+		return v
+	}
+	return http.StatusInternalServerError
+}
+
+type ErrorsPayload jsonapi.ErrorsPayload
+
+// Error writes an HTTP response with a JSON-API encoded error.
+func Error(w http.ResponseWriter, err error) {
+	code := lookupHTTPCode(err)
 	w.Header().Set("Content-type", jsonapi.MediaType)
 	w.WriteHeader(code)
 	jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{

--- a/organization/api.go
+++ b/organization/api.go
@@ -32,13 +32,13 @@ func (h *api) addHandlers(r *mux.Router) {
 func (h *api) GetOrganization(w http.ResponseWriter, r *http.Request) {
 	name, err := decode.Param("name", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	org, err := h.svc.GetOrganization(r.Context(), name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -48,13 +48,13 @@ func (h *api) GetOrganization(w http.ResponseWriter, r *http.Request) {
 func (h *api) ListOrganizations(w http.ResponseWriter, r *http.Request) {
 	var opts OrganizationListOptions
 	if err := decode.Query(&opts, r.URL.Query()); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	list, err := h.svc.ListOrganizations(r.Context(), opts)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -64,13 +64,13 @@ func (h *api) ListOrganizations(w http.ResponseWriter, r *http.Request) {
 func (h *api) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
 	name, err := decode.Param("name", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	opts := jsonapi.OrganizationUpdateOptions{}
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	org, err := h.svc.UpdateOrganization(r.Context(), name, OrganizationUpdateOptions{
@@ -79,7 +79,7 @@ func (h *api) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
 		SessionTimeout:  opts.SessionTimeout,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -89,12 +89,12 @@ func (h *api) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
 func (h *api) DeleteOrganization(w http.ResponseWriter, r *http.Request) {
 	name, err := decode.Param("name", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	if err := h.svc.DeleteOrganization(r.Context(), name); err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -104,13 +104,13 @@ func (h *api) DeleteOrganization(w http.ResponseWriter, r *http.Request) {
 func (h *api) GetEntitlements(w http.ResponseWriter, r *http.Request) {
 	name, err := decode.Param("name", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	entitlements, err := h.svc.getEntitlements(r.Context(), name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (h *api) writeResponse(w http.ResponseWriter, r *http.Request, v any, opts 
 	case Entitlements:
 		payload = (*jsonapi.Entitlements)(&v)
 	default:
-		jsonapi.Error(w, http.StatusInternalServerError, fmt.Errorf("cannot marshal unknown type: %T", v))
+		jsonapi.Error(w, fmt.Errorf("cannot marshal unknown type: %T", v))
 		return
 	}
 	jsonapi.WriteResponse(w, r, payload, opts...)

--- a/organization/jsonapi.go
+++ b/organization/jsonapi.go
@@ -21,7 +21,7 @@ func (m *JSONAPIMarshaler) ToOrganization(org *Organization) *jsonapi.Organizati
 
 func (m *JSONAPIMarshaler) toList(from *OrganizationList) *jsonapi.OrganizationList {
 	to := &jsonapi.OrganizationList{
-		Pagination: from.Pagination.ToJSONAPI(),
+		Pagination: jsonapi.NewPagination(from.Pagination),
 	}
 	for _, item := range from.Items {
 		to.Items = append(to.Items, m.ToOrganization(item))

--- a/orgcreator/api.go
+++ b/orgcreator/api.go
@@ -27,7 +27,7 @@ func (h *api) addHandlers(r *mux.Router) {
 func (h *api) CreateOrganization(w http.ResponseWriter, r *http.Request) {
 	var opts jsonapi.OrganizationCreateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -37,7 +37,7 @@ func (h *api) CreateOrganization(w http.ResponseWriter, r *http.Request) {
 		SessionTimeout:  opts.SessionTimeout,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 

--- a/pagination.go
+++ b/pagination.go
@@ -4,8 +4,6 @@ import (
 	"math"
 	"net/url"
 	"strconv"
-
-	"github.com/leg100/otf/http/jsonapi"
 )
 
 const (
@@ -17,32 +15,32 @@ const (
 // Pagination is used to return the pagination details of an API request.
 type Pagination struct {
 	// list options from API request
-	opts ListOptions
+	Opts ListOptions
 	// total unpaginated count
-	count int
+	Count int
 }
 
-func (p *Pagination) CurrentPage() int { return p.opts.PageNumber }
-func (p *Pagination) TotalCount() int  { return p.count }
+func (p *Pagination) CurrentPage() int { return p.Opts.PageNumber }
+func (p *Pagination) TotalCount() int  { return p.Count }
 
 // PrevPage returns the previous page number or nil if there isn't one.
 func (p *Pagination) PrevPage() *int {
-	if p.opts.SanitizedPageNumber() > 1 {
-		return Int(p.opts.prevPage())
+	if p.Opts.SanitizedPageNumber() > 1 {
+		return Int(p.Opts.prevPage())
 	}
 	return nil
 }
 
 // NextPage returns the next page number or nil if there isn't one.
 func (p *Pagination) NextPage() *int {
-	if p.opts.SanitizedPageNumber() < p.TotalPages() {
-		return Int(p.opts.nextPage())
+	if p.Opts.SanitizedPageNumber() < p.TotalPages() {
+		return Int(p.Opts.nextPage())
 	}
 	return nil
 }
 
 func (p *Pagination) TotalPages() int {
-	pages := float64(p.count) / float64(p.opts.SanitizedPageSize())
+	pages := float64(p.Count) / float64(p.Opts.SanitizedPageSize())
 	// total must be a round number greater than 0
 	return int(math.Max(1, math.Ceil(pages)))
 }
@@ -50,43 +48,22 @@ func (p *Pagination) TotalPages() int {
 // NextPageQuery produces query params for the next page
 func (p *Pagination) NextPageQuery() string {
 	q := url.Values{}
-	q.Add("page[number]", strconv.Itoa(p.opts.nextPage()))
-	q.Add("page[size]", strconv.Itoa(p.opts.SanitizedPageSize()))
+	q.Add("page[number]", strconv.Itoa(p.Opts.nextPage()))
+	q.Add("page[size]", strconv.Itoa(p.Opts.SanitizedPageSize()))
 	return q.Encode()
 }
 
 // PrevPageQuery produces query params for the previous page
 func (p *Pagination) PrevPageQuery() string {
 	q := url.Values{}
-	q.Add("page[number]", strconv.Itoa(p.opts.prevPage()))
-	q.Add("page[size]", strconv.Itoa(p.opts.SanitizedPageSize()))
+	q.Add("page[number]", strconv.Itoa(p.Opts.prevPage()))
+	q.Add("page[size]", strconv.Itoa(p.Opts.SanitizedPageSize()))
 	return q.Encode()
-}
-
-// ToJSONAPI assembles a JSON-API DTO for wire serialization.
-func (p *Pagination) ToJSONAPI() *jsonapi.Pagination {
-	return &jsonapi.Pagination{
-		CurrentPage:  p.opts.SanitizedPageNumber(),
-		PreviousPage: p.PrevPage(),
-		NextPage:     p.NextPage(),
-		TotalPages:   p.TotalPages(),
-		TotalCount:   p.count,
-	}
 }
 
 // NewPagination constructs a Pagination obj.
 func NewPagination(opts ListOptions, count int) *Pagination {
 	return &Pagination{opts, count}
-}
-
-// NewPaginationFromJSONAPI constructs pagination from a json:api struct
-func NewPaginationFromJSONAPI(json *jsonapi.Pagination) *Pagination {
-	return &Pagination{
-		count: json.TotalCount,
-		// we can't determine the page size so we'll just pass in 0 which
-		// NewListOptions interprets as the default page size
-		opts: ListOptions{PageNumber: json.CurrentPage, PageSize: 0},
-	}
 }
 
 // ListOptions is used to specify pagination options when making API requests.

--- a/run/api.go
+++ b/run/api.go
@@ -70,11 +70,11 @@ func (s *api) addHandlers(r *mux.Router) {
 func (s *api) create(w http.ResponseWriter, r *http.Request) {
 	var opts jsonapi.RunCreateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	if opts.Workspace == nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, fmt.Errorf("missing workspace"))
+		jsonapi.Error(w,  fmt.Errorf("%w: %s", otf.ErrMissingParameter, "workspace"))
 		return
 	}
 	var configurationVersionID *string
@@ -92,7 +92,7 @@ func (s *api) create(w http.ResponseWriter, r *http.Request) {
 		ReplaceAddrs:           opts.ReplaceAddrs,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -105,13 +105,13 @@ func (s *api) startPhase(w http.ResponseWriter, r *http.Request) {
 		Phase otf.PhaseType `schema:"phase,required"`
 	}
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	run, err := s.svc.StartPhase(r.Context(), params.RunID, params.Phase, PhaseStartOptions{})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -124,13 +124,13 @@ func (s *api) finishPhase(w http.ResponseWriter, r *http.Request) {
 		Phase otf.PhaseType `schema:"phase,required"`
 	}
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	run, err := s.svc.FinishPhase(r.Context(), params.RunID, params.Phase, PhaseFinishOptions{})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -140,13 +140,13 @@ func (s *api) finishPhase(w http.ResponseWriter, r *http.Request) {
 func (s *api) get(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	run, err := s.svc.get(r.Context(), id)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -165,13 +165,13 @@ func (s *api) getRunQueue(w http.ResponseWriter, r *http.Request) {
 
 func (s *api) listRuns(w http.ResponseWriter, r *http.Request, opts RunListOptions) {
 	if err := decode.All(&opts, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	list, err := s.svc.ListRuns(r.Context(), opts)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -181,12 +181,12 @@ func (s *api) listRuns(w http.ResponseWriter, r *http.Request, opts RunListOptio
 func (s *api) applyRun(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	if err := s.svc.Apply(r.Context(), id); err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -196,15 +196,15 @@ func (s *api) applyRun(w http.ResponseWriter, r *http.Request) {
 func (s *api) discard(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
-	if err = s.svc.discard(r.Context(), id); err == ErrRunDiscardNotAllowed {
-		jsonapi.Error(w, http.StatusConflict, err)
+	if err = s.svc.discard(r.Context(), id); err == otf.ErrRunDiscardNotAllowed {
+		jsonapi.Error(w,  err)
 		return
 	} else if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -214,16 +214,16 @@ func (s *api) discard(w http.ResponseWriter, r *http.Request) {
 func (s *api) cancel(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	_, err = s.svc.Cancel(r.Context(), id)
-	if err == ErrRunCancelNotAllowed {
-		jsonapi.Error(w, http.StatusConflict, err)
+	if err == otf.ErrRunCancelNotAllowed {
+		jsonapi.Error(w,  err)
 		return
 	} else if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -233,16 +233,16 @@ func (s *api) cancel(w http.ResponseWriter, r *http.Request) {
 func (s *api) forceCancel(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	err = s.svc.forceCancel(r.Context(), id)
-	if err == ErrRunForceCancelNotAllowed {
-		jsonapi.Error(w, http.StatusConflict, err)
+	if err == otf.ErrRunForceCancelNotAllowed {
+		jsonapi.Error(w,  err)
 		return
 	} else if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -252,18 +252,18 @@ func (s *api) forceCancel(w http.ResponseWriter, r *http.Request) {
 func (s *api) getPlanFile(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	opts := planFileOptions{}
 	if err := decode.Query(&opts, r.URL.Query()); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	file, err := s.svc.GetPlanFile(r.Context(), id, opts.Format)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -276,24 +276,24 @@ func (s *api) getPlanFile(w http.ResponseWriter, r *http.Request) {
 func (s *api) uploadPlanFile(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	opts := planFileOptions{}
 	if err := decode.Query(&opts, r.URL.Query()); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	buf := new(bytes.Buffer)
 	if _, err := io.Copy(buf, r.Body); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	err = s.svc.UploadPlanFile(r.Context(), id, buf.Bytes(), opts.Format)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -303,13 +303,13 @@ func (s *api) uploadPlanFile(w http.ResponseWriter, r *http.Request) {
 func (s *api) getLockFile(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	file, err := s.svc.GetLockFile(r.Context(), id)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -322,19 +322,19 @@ func (s *api) getLockFile(w http.ResponseWriter, r *http.Request) {
 func (s *api) uploadLockFile(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	buf := new(bytes.Buffer)
 	if _, err := io.Copy(buf, r.Body); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	err = s.svc.UploadLockFile(r.Context(), id, buf.Bytes())
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -352,14 +352,14 @@ func (s *api) uploadLockFile(w http.ResponseWriter, r *http.Request) {
 func (s *api) getPlan(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("plan_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	// otf's plan IDs are simply the corresponding run ID
 	run, err := s.svc.get(r.Context(), otf.ConvertID(id, "run"))
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -372,14 +372,14 @@ func (s *api) getPlan(w http.ResponseWriter, r *http.Request) {
 func (s *api) getPlanJSON(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("plan_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	// otf's plan IDs are simply the corresponding run ID
 	json, err := s.svc.GetPlanFile(r.Context(), otf.ConvertID(id, "run"), PlanFormatJSON)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	if _, err := w.Write(json); err != nil {
@@ -391,14 +391,14 @@ func (s *api) getPlanJSON(w http.ResponseWriter, r *http.Request) {
 func (s *api) getApply(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("apply_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	// otf's apply IDs are simply the corresponding run ID
 	run, err := s.svc.get(r.Context(), otf.ConvertID(id, "run"))
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -463,7 +463,7 @@ func (s *api) writeResponse(w http.ResponseWriter, r *http.Request, v any, opts 
 		payload, err = s.toPhase(v, r)
 	}
 	if err != nil {
-		jsonapi.Error(w, http.StatusInternalServerError, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	jsonapi.WriteResponse(w, r, payload, opts...)

--- a/run/jsonapi_marshal.go
+++ b/run/jsonapi_marshal.go
@@ -161,7 +161,7 @@ func (m *JSONAPIMarshaler) toRun(run *Run, r *http.Request) (*jsonapi.Run, error
 
 func (m JSONAPIMarshaler) toList(from *RunList, r *http.Request) (*jsonapi.RunList, error) {
 	to := &jsonapi.RunList{
-		Pagination: from.Pagination.ToJSONAPI(),
+		Pagination: jsonapi.NewPagination(from.Pagination),
 	}
 	for _, i := range from.Items {
 		run, err := m.toRun(i, r)

--- a/run/jsonapi_unmarshal.go
+++ b/run/jsonapi_unmarshal.go
@@ -42,7 +42,7 @@ func newFromJSONAPI(from *jsonapi.Run) *Run {
 // newListFromJSONAPI constructs a run list from a json:api struct
 func newListFromJSONAPI(from *jsonapi.RunList) *RunList {
 	to := RunList{
-		Pagination: otf.NewPaginationFromJSONAPI(from.Pagination),
+		Pagination: jsonapi.NewPaginationFromJSONAPI(from.Pagination),
 	}
 	for _, i := range from.Items {
 		to.Items = append(to.Items, newFromJSONAPI(i))

--- a/run/run.go
+++ b/run/run.go
@@ -22,13 +22,7 @@ const (
 	defaultRefresh = true
 )
 
-var (
-	ErrRunDiscardNotAllowed      = errors.New("run was not paused for confirmation or priority; discard not allowed")
-	ErrRunCancelNotAllowed       = errors.New("run was not planning or applying; cancel not allowed")
-	ErrRunForceCancelNotAllowed  = errors.New("run was not planning or applying, has not been canceled non-forcefully, or the cool-off period has not yet passed")
-	ErrInvalidRunGetOptions      = errors.New("invalid run get options")
-	ErrInvalidRunStateTransition = errors.New("invalid run state transition")
-)
+var ErrInvalidRunStateTransition = errors.New("invalid run state transition")
 
 type (
 	PlanFormat string
@@ -181,7 +175,7 @@ func (r *Run) Phase() otf.PhaseType {
 // Discard updates the state of a run to reflect it having been discarded.
 func (r *Run) Discard() error {
 	if !r.Discardable() {
-		return ErrRunDiscardNotAllowed
+		return otf.ErrRunDiscardNotAllowed
 	}
 	r.updateStatus(otf.RunDiscarded)
 
@@ -197,7 +191,7 @@ func (r *Run) Discard() error {
 // enqueued (for an agent to kill an in progress process)
 func (r *Run) Cancel() (enqueue bool, err error) {
 	if !r.Cancelable() {
-		return false, ErrRunCancelNotAllowed
+		return false, otf.ErrRunCancelNotAllowed
 	}
 	// permit run to be force canceled after a cool off period of 10 seconds has
 	// elapsed.
@@ -231,7 +225,7 @@ func (r *Run) ForceCancel() error {
 		r.updateStatus(otf.RunCanceled)
 		return nil
 	}
-	return ErrRunForceCancelNotAllowed
+	return otf.ErrRunForceCancelNotAllowed
 }
 
 // Done determines whether run has reached an end state, e.g. applied,

--- a/scheduler/queue.go
+++ b/scheduler/queue.go
@@ -144,7 +144,7 @@ func (q *queue) scheduleRun(ctx context.Context, run *run.Run) error {
 
 	ws, err := q.LockWorkspace(ctx, q.ws.ID, &run.ID)
 	if err != nil {
-		if errors.Is(err, workspace.ErrWorkspaceAlreadyLocked) {
+		if errors.Is(err, otf.ErrWorkspaceAlreadyLocked) {
 			// User has locked workspace in the small window of time between
 			// getting the lock above and attempting to enqueue plan.
 			q.V(0).Info("workspace locked by user; cannot schedule run", "run", run.ID)

--- a/state/jsonapi_marshaler.go
+++ b/state/jsonapi_marshaler.go
@@ -25,7 +25,7 @@ func (m *jsonapiMarshaler) toVersion(from *Version) *jsonapi.StateVersion {
 // ToJSONAPI assembles a struct suitable for marshalling into json-api
 func (m *jsonapiMarshaler) toList(from *VersionList) *jsonapi.StateVersionList {
 	jl := &jsonapi.StateVersionList{
-		Pagination: from.Pagination.ToJSONAPI(),
+		Pagination: jsonapi.NewPagination(from.Pagination),
 	}
 	for _, item := range from.Items {
 		jl.Items = append(jl.Items, m.toVersion(item))

--- a/variable/api.go
+++ b/variable/api.go
@@ -31,12 +31,12 @@ func (h *api) addHandlers(r *mux.Router) {
 func (h *api) create(w http.ResponseWriter, r *http.Request) {
 	workspaceID, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	var opts jsonapi.VariableCreateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	variable, err := h.svc.CreateVariable(r.Context(), workspaceID, CreateVariableOptions{
@@ -48,7 +48,7 @@ func (h *api) create(w http.ResponseWriter, r *http.Request) {
 		HCL:         opts.HCL,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	h.writeResponse(w, r, variable, jsonapi.WithCode(http.StatusCreated))
@@ -57,12 +57,12 @@ func (h *api) create(w http.ResponseWriter, r *http.Request) {
 func (h *api) get(w http.ResponseWriter, r *http.Request) {
 	variableID, err := decode.Param("variable_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	variable, err := h.svc.GetVariable(r.Context(), variableID)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	h.writeResponse(w, r, variable)
@@ -71,12 +71,12 @@ func (h *api) get(w http.ResponseWriter, r *http.Request) {
 func (h *api) list(w http.ResponseWriter, r *http.Request) {
 	workspaceID, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	variables, err := h.svc.ListVariables(r.Context(), workspaceID)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	h.writeResponse(w, r, variables)
@@ -85,12 +85,12 @@ func (h *api) list(w http.ResponseWriter, r *http.Request) {
 func (h *api) update(w http.ResponseWriter, r *http.Request) {
 	variableID, err := decode.Param("variable_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	var opts jsonapi.VariableUpdateOptions
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	updated, err := h.svc.UpdateVariable(r.Context(), variableID, UpdateVariableOptions{
@@ -102,7 +102,7 @@ func (h *api) update(w http.ResponseWriter, r *http.Request) {
 		HCL:         opts.HCL,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	h.writeResponse(w, r, updated)
@@ -111,12 +111,12 @@ func (h *api) update(w http.ResponseWriter, r *http.Request) {
 func (h *api) delete(w http.ResponseWriter, r *http.Request) {
 	variableID, err := decode.Param("variable_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	_, err = h.svc.DeleteVariable(r.Context(), variableID)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w, err)
 		return
 	}
 }
@@ -155,7 +155,7 @@ func (h *api) writeResponse(w http.ResponseWriter, r *http.Request, v any, opts 
 		payload = &to
 	default:
 		err := fmt.Errorf("no json:api struct found for %T", v)
-		jsonapi.Error(w, http.StatusInternalServerError, err)
+		jsonapi.Error(w, err)
 		return
 	}
 	jsonapi.WriteResponse(w, r, payload, opts...)

--- a/variable/db.go
+++ b/variable/db.go
@@ -50,11 +50,10 @@ func (pdb *pgdb) create(ctx context.Context, v *Variable) error {
 func (pdb *pgdb) update(ctx context.Context, variableID string, fn func(*Variable) error) (*Variable, error) {
 	var variable *Variable
 	err := pdb.tx(ctx, func(tx db) error {
-		var err error
 		// retrieve variable
 		row, err := tx.FindVariableForUpdate(ctx, sql.String(variableID))
 		if err != nil {
-			return sql.Error(err)
+			return err
 		}
 		variable = pgRow(row).toVariable()
 
@@ -74,13 +73,13 @@ func (pdb *pgdb) update(ctx context.Context, variableID string, fn func(*Variabl
 		})
 		return err
 	})
-	return variable, err
+	return variable, sql.Error(err)
 }
 
 func (pdb *pgdb) list(ctx context.Context, workspaceID string) ([]*Variable, error) {
 	rows, err := pdb.FindVariables(ctx, sql.String(workspaceID))
 	if err != nil {
-		return nil, err
+		return nil, sql.Error(err)
 	}
 
 	var variables []*Variable
@@ -93,7 +92,7 @@ func (pdb *pgdb) list(ctx context.Context, workspaceID string) ([]*Variable, err
 func (pdb *pgdb) get(ctx context.Context, variableID string) (*Variable, error) {
 	row, err := pdb.FindVariable(ctx, sql.String(variableID))
 	if err != nil {
-		return nil, err
+		return nil, sql.Error(err)
 	}
 
 	return pgRow(row).toVariable(), nil

--- a/variable/service.go
+++ b/variable/service.go
@@ -152,7 +152,7 @@ func (s *service) DeleteVariable(ctx context.Context, variableID string) (*Varia
 	// retrieve existing in order to retrieve workspace ID for authorization
 	existing, err := s.db.get(ctx, variableID)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving variable")
+		return nil, err
 	}
 
 	subject, err := s.workspace.CanAccess(ctx, rbac.DeleteVariableAction, existing.WorkspaceID)

--- a/workspace/api.go
+++ b/workspace/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/leg100/otf"
 	otfhttp "github.com/leg100/otf/http"
 	"github.com/leg100/otf/http/decode"
 	"github.com/leg100/otf/http/jsonapi"
@@ -49,11 +50,11 @@ func (a *api) addHandlers(r *mux.Router) {
 func (a *api) create(w http.ResponseWriter, r *http.Request) {
 	var params jsonapi.WorkspaceCreateOptions
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	if err := jsonapi.UnmarshalPayload(r.Body, &params); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	opts := CreateOptions{
@@ -78,7 +79,7 @@ func (a *api) create(w http.ResponseWriter, r *http.Request) {
 	if params.Operations != nil {
 		if params.ExecutionMode != nil {
 			err := errors.New("operations is deprecated and cannot be specified when execution mode is used")
-			jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+			jsonapi.Error(w,  err)
 			return
 		}
 		if *params.Operations {
@@ -90,7 +91,7 @@ func (a *api) create(w http.ResponseWriter, r *http.Request) {
 	if params.VCSRepo != nil {
 		if params.VCSRepo.Identifier == nil || params.VCSRepo.OAuthTokenID == nil {
 			err := errors.New("must specify both oauth-token-id and identifier attributes for vcs-repo")
-			jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+			jsonapi.Error(w,  err)
 			return
 		}
 		opts.ConnectOptions = &ConnectOptions{
@@ -104,7 +105,7 @@ func (a *api) create(w http.ResponseWriter, r *http.Request) {
 
 	ws, err := a.svc.CreateWorkspace(r.Context(), opts)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -114,13 +115,13 @@ func (a *api) create(w http.ResponseWriter, r *http.Request) {
 func (a *api) GetWorkspace(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.GetWorkspace(r.Context(), id)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -130,13 +131,13 @@ func (a *api) GetWorkspace(w http.ResponseWriter, r *http.Request) {
 func (a *api) GetWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 	var params byName
 	if err := decode.All(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.GetWorkspaceByName(r.Context(), params.Organization, params.Name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -146,13 +147,13 @@ func (a *api) GetWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 func (a *api) list(w http.ResponseWriter, r *http.Request) {
 	var params ListOptions
 	if err := decode.All(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	wsl, err := a.svc.ListWorkspaces(r.Context(), params)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -165,7 +166,7 @@ func (a *api) list(w http.ResponseWriter, r *http.Request) {
 func (a *api) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	workspaceID, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -178,13 +179,13 @@ func (a *api) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 func (a *api) UpdateWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 	var params byName
 	if err := decode.Route(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.GetWorkspaceByName(r.Context(), params.Organization, params.Name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -194,16 +195,16 @@ func (a *api) UpdateWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 func (a *api) LockWorkspace(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.LockWorkspace(r.Context(), id, nil)
-	if err == ErrWorkspaceAlreadyLocked {
-		jsonapi.Error(w, http.StatusConflict, err)
+	if err == otf.ErrWorkspaceAlreadyLocked {
+		jsonapi.Error(w,  err)
 		return
 	} else if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -213,21 +214,21 @@ func (a *api) LockWorkspace(w http.ResponseWriter, r *http.Request) {
 func (a *api) UnlockWorkspace(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	var opts unlockOptions
 	if err := decode.Form(&opts, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.UnlockWorkspace(r.Context(), id, nil, opts.Force)
-	if err == ErrWorkspaceAlreadyUnlocked {
-		jsonapi.Error(w, http.StatusConflict, err)
+	if err == otf.ErrWorkspaceAlreadyUnlocked {
+		jsonapi.Error(w,  err)
 		return
 	} else if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -237,13 +238,13 @@ func (a *api) UnlockWorkspace(w http.ResponseWriter, r *http.Request) {
 func (a *api) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	workspaceID, err := decode.Param("workspace_id", r)
 	if err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	_, err = a.svc.DeleteWorkspace(r.Context(), workspaceID)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -252,18 +253,18 @@ func (a *api) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 func (a *api) DeleteWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 	var params byName
 	if err := decode.All(&params, r); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
 	ws, err := a.svc.GetWorkspaceByName(r.Context(), params.Organization, params.Name)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	_, err = a.svc.DeleteWorkspace(r.Context(), ws.ID)
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -272,11 +273,11 @@ func (a *api) DeleteWorkspaceByName(w http.ResponseWriter, r *http.Request) {
 func (a *api) updateWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) {
 	opts := jsonapi.WorkspaceUpdateOptions{}
 	if err := jsonapi.UnmarshalPayload(r.Body, &opts); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	if err := opts.Validate(); err != nil {
-		jsonapi.Error(w, http.StatusUnprocessableEntity, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -296,7 +297,7 @@ func (a *api) updateWorkspace(w http.ResponseWriter, r *http.Request, workspaceI
 		WorkingDirectory:           opts.WorkingDirectory,
 	})
 	if err != nil {
-		jsonapi.Error(w, http.StatusNotFound, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 
@@ -317,7 +318,7 @@ func (a *api) writeResponse(w http.ResponseWriter, r *http.Request, v any, opts 
 		payload, err = a.toWorkspace(v, r)
 	}
 	if err != nil {
-		jsonapi.Error(w, http.StatusInternalServerError, err)
+		jsonapi.Error(w,  err)
 		return
 	}
 	jsonapi.WriteResponse(w, r, payload, opts...)

--- a/workspace/jsonapi_marshaler.go
+++ b/workspace/jsonapi_marshaler.go
@@ -102,6 +102,6 @@ func (m *jsonapiMarshaler) toList(list *WorkspaceList, r *http.Request) (*jsonap
 	}
 	return &jsonapi.WorkspaceList{
 		Items:      items,
-		Pagination: list.Pagination.ToJSONAPI(),
+		Pagination: jsonapi.NewPagination(list.Pagination),
 	}, nil
 }

--- a/workspace/jsonapi_unmarshal.go
+++ b/workspace/jsonapi_unmarshal.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"github.com/leg100/otf"
 	"github.com/leg100/otf/http/jsonapi"
 )
 
@@ -43,7 +42,7 @@ func unmarshalJSONAPI(w *jsonapi.Workspace) *Workspace {
 // unmarshalListJSONAPI converts a DTO into a workspace list
 func unmarshalListJSONAPI(json *jsonapi.WorkspaceList) *WorkspaceList {
 	wl := WorkspaceList{
-		Pagination: otf.NewPaginationFromJSONAPI(json.Pagination),
+		Pagination: jsonapi.NewPaginationFromJSONAPI(json.Pagination),
 	}
 	for _, i := range json.Items {
 		wl.Items = append(wl.Items, unmarshalJSONAPI(i))

--- a/workspace/lock.go
+++ b/workspace/lock.go
@@ -49,7 +49,7 @@ func (l *Lock) Lock(state LockedState) error {
 // Unlock the lock.
 func (l *Lock) Unlock(state LockedState, force bool) error {
 	if !l.Locked() {
-		return ErrWorkspaceAlreadyUnlocked
+		return otf.ErrWorkspaceAlreadyUnlocked
 	}
 	if err := l.LockedState.CanUnlock(state, force); err != nil {
 		return err

--- a/workspace/lock_db.go
+++ b/workspace/lock_db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgtype"
+	"github.com/leg100/otf"
 	"github.com/leg100/otf/sql"
 	"github.com/leg100/otf/sql/pggen"
 )
@@ -39,7 +40,7 @@ func (db *pgdb) toggleLock(ctx context.Context, workspaceID string, togglefn fun
 			params.RunID = pgtype.Text{Status: pgtype.Null}
 			params.Username = pgtype.Text{Status: pgtype.Null}
 		default:
-			return ErrWorkspaceInvalidLock
+			return otf.ErrWorkspaceInvalidLock
 		}
 		_, err = tx.UpdateWorkspaceLockByID(ctx, params)
 		if err != nil {

--- a/workspace/lock_run.go
+++ b/workspace/lock_run.go
@@ -1,5 +1,7 @@
 package workspace
 
+import "github.com/leg100/otf"
+
 // RunLock is a workspace lock held by a run
 type RunLock struct {
 	ID string
@@ -12,7 +14,7 @@ func (RunLock) CanLock(lock LockedState) error {
 	if _, ok := lock.(RunLock); ok {
 		return nil
 	}
-	return ErrWorkspaceAlreadyLocked
+	return otf.ErrWorkspaceAlreadyLocked
 }
 
 func (RunLock) CanUnlock(lock LockedState, force bool) error {
@@ -21,7 +23,7 @@ func (RunLock) CanUnlock(lock LockedState, force bool) error {
 		if force {
 			return nil
 		}
-		return ErrWorkspaceLockedByDifferentUser
+		return otf.ErrWorkspaceLockedByDifferentUser
 	}
 	// anyone/anything else is allowed to unlock a run lock
 	return nil

--- a/workspace/lock_service.go
+++ b/workspace/lock_service.go
@@ -82,7 +82,7 @@ func GetLockedState(subject otf.Subject, runID *string) (LockedState, error) {
 	} else if user, ok := subject.(*auth.User); ok {
 		state = UserLock{ID: user.ID, Username: user.Username}
 	} else {
-		return nil, ErrWorkspaceInvalidLock
+		return nil, otf.ErrWorkspaceInvalidLock
 	}
 	return state, nil
 }

--- a/workspace/lock_user.go
+++ b/workspace/lock_user.go
@@ -1,5 +1,7 @@
 package workspace
 
+import "github.com/leg100/otf"
+
 // UserLock is a lock held by a user
 type UserLock struct {
 	ID, Username string
@@ -9,14 +11,14 @@ func (l UserLock) String() string { return l.Username }
 
 func (l UserLock) CanLock(lock LockedState) error {
 	// nothing can replace a user lock; it can only be unlocked
-	return ErrWorkspaceAlreadyLocked
+	return otf.ErrWorkspaceAlreadyLocked
 }
 
 func (l UserLock) CanUnlock(state LockedState, force bool) error {
 	// only a user lock can unlock a user lock
 	user, ok := state.(UserLock)
 	if !ok {
-		return ErrWorkspaceUnlockDenied
+		return otf.ErrWorkspaceUnlockDenied
 	}
 
 	// any user lock can forceably unlock a user lock
@@ -28,5 +30,5 @@ func (l UserLock) CanUnlock(state LockedState, force bool) error {
 	if l == user {
 		return nil
 	}
-	return ErrWorkspaceLockedByDifferentUser
+	return otf.ErrWorkspaceLockedByDifferentUser
 }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -3,7 +3,6 @@ package workspace
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/leg100/otf"
@@ -21,15 +20,6 @@ const (
 
 	MinTerraformVersion     = "1.2.0"
 	DefaultTerraformVersion = "1.3.7"
-)
-
-var (
-	ErrWorkspaceAlreadyLocked         = errors.New("workspace already locked")
-	ErrWorkspaceLockedByDifferentUser = errors.New("workspace locked by different user")
-	ErrWorkspaceAlreadyUnlocked       = errors.New("workspace already unlocked")
-	ErrWorkspaceUnlockDenied          = errors.New("unauthorized to unlock workspace")
-	ErrWorkspaceInvalidLock           = errors.New("invalid workspace lock")
-	ErrUnsupportedTerraformVersion    = fmt.Errorf("only terraform versions >= %s are supported", MinTerraformVersion)
 )
 
 type (
@@ -335,7 +325,7 @@ func (ws *Workspace) setTerraformVersion(v string) error {
 		return otf.ErrInvalidTerraformVersion
 	}
 	if result := semver.Compare(v, MinTerraformVersion); result < 0 {
-		return ErrUnsupportedTerraformVersion
+		return otf.ErrUnsupportedTerraformVersion
 	}
 	ws.TerraformVersion = v
 	return nil

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -58,7 +58,7 @@ func TestNewWorkspace(t *testing.T) {
 				Organization:     otf.String("my-org"),
 				TerraformVersion: otf.String("0.14.0"),
 			},
-			want: ErrUnsupportedTerraformVersion,
+			want: otf.ErrUnsupportedTerraformVersion,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Currently otf responds with a 422 if the request payload body is incorrect, or a parameter is missing, which is correct behaviour. However for all other errors, it inconsistently responds with a 500 or a 404, regardless of the error.

This PR fixes that, by mapping otf errors to an appropriate http code.