### PR TITLE
Auto-create nominated site admins

### DIFF
--- a/auth/db_row.go
+++ b/auth/db_row.go
@@ -21,6 +21,7 @@ func (row userRow) toUser() *User {
 		CreatedAt: row.CreatedAt.Time.UTC(),
 		UpdatedAt: row.UpdatedAt.Time.UTC(),
 		Username:  row.Username.String,
+		SiteAdmin: row.SiteAdmin,
 	}
 	for _, tr := range row.Teams {
 		user.Teams = append(user.Teams, teamRow(tr).toTeam())

--- a/auth/user_db.go
+++ b/auth/user_db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgtype"
 	"github.com/leg100/otf"
 	"github.com/leg100/otf/sql"
 	"github.com/leg100/otf/sql/pggen"
@@ -116,21 +117,40 @@ func (db *pgdb) DeleteUser(ctx context.Context, spec UserSpec) error {
 	return nil
 }
 
-func (db *pgdb) setSiteAdmins(ctx context.Context, usernames ...string) error {
-	err := db.Tx(ctx, func(tx otf.DB) error {
+// setSiteAdmins authoritatively promotes the given users to site admins,
+// demoting all other site admins. The list of newly promoted and demoted site
+// admins is returned.
+func (db *pgdb) setSiteAdmins(ctx context.Context, usernames ...string) (promoted []string, demoted []string, err error) {
+	var resetted, updated []pgtype.Text
+	err = db.Tx(ctx, func(tx otf.DB) (err error) {
 		// First demote any existing site admins...
-		if _, err := tx.ResetUserSiteAdmins(ctx); err != nil {
+		resetted, err = tx.ResetUserSiteAdmins(ctx)
+		if err != nil {
 			return err
 		}
 		// ...then promote any specified usernames
 		if len(usernames) > 0 {
-			users, err := tx.UpdateUserSiteAdmins(ctx, usernames)
+			updated, err = tx.UpdateUserSiteAdmins(ctx, usernames)
 			if err != nil {
 				return err
 			}
-			db.Info("made users site admins", "users", users)
 		}
 		return nil
 	})
-	return sql.Error(err)
+	return pgtextSliceDiff(updated, resetted), pgtextSliceDiff(resetted, updated), nil
+}
+
+// pgtextSliceDiff returns the elements in `a` that aren't in `b`.
+func pgtextSliceDiff(a, b []pgtype.Text) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x.String] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x.String]; !found {
+			diff = append(diff, x.String)
+		}
+	}
+	return diff
 }

--- a/auth/user_db.go
+++ b/auth/user_db.go
@@ -118,8 +118,8 @@ func (db *pgdb) DeleteUser(ctx context.Context, spec UserSpec) error {
 }
 
 // setSiteAdmins authoritatively promotes the given users to site admins,
-// demoting all other site admins. The list of newly promoted and demoted site
-// admins is returned.
+// demoting all other site admins. The list of newly promoted and demoted users
+// is returned.
 func (db *pgdb) setSiteAdmins(ctx context.Context, usernames ...string) (promoted []string, demoted []string, err error) {
 	var resetted, updated []pgtype.Text
 	err = db.Tx(ctx, func(tx otf.DB) (err error) {
@@ -137,6 +137,9 @@ func (db *pgdb) setSiteAdmins(ctx context.Context, usernames ...string) (promote
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 	return pgtextSliceDiff(updated, resetted), pgtextSliceDiff(resetted, updated), nil
 }
 

--- a/auth/user_db.go
+++ b/auth/user_db.go
@@ -124,9 +124,11 @@ func (db *pgdb) setSiteAdmins(ctx context.Context, usernames ...string) error {
 		}
 		// ...then promote any specified usernames
 		if len(usernames) > 0 {
-			if _, err := tx.UpdateUserSiteAdmins(ctx, usernames); err != nil {
+			users, err := tx.UpdateUserSiteAdmins(ctx, usernames)
+			if err != nil {
 				return err
 			}
+			db.Info("made users site admins", "users", users)
 		}
 		return nil
 	})

--- a/auth/user_service.go
+++ b/auth/user_service.go
@@ -167,10 +167,11 @@ func (a *service) SetSiteAdmins(ctx context.Context, usernames ...string) error 
 			}
 		}
 	}
-	if err := a.db.setSiteAdmins(ctx, usernames...); err != nil {
+	promoted, demoted, err := a.db.setSiteAdmins(ctx, usernames...)
+	if err != nil {
 		a.Error(err, "setting site admins", "users", usernames)
 		return err
 	}
-	a.V(0).Info("set site admins", "users", usernames)
+	a.V(0).Info("set site admins", "admins", usernames, "promoted", promoted, "demoted", demoted)
 	return nil
 }

--- a/cmd/otfd/main.go
+++ b/cmd/otfd/main.go
@@ -46,12 +46,15 @@ func parseFlags(ctx context.Context, args []string, out io.Writer) error {
 				return err
 			}
 
-			d, err := daemon.New(cmd.Context(), logger, cfg)
+			// Confer superuser privileges on all calls to service endpoints
+			ctx := otf.AddSubjectToContext(cmd.Context(), &otf.Superuser{Username: "app-user"})
+
+			d, err := daemon.New(ctx, logger, cfg)
 			if err != nil {
 				return err
 			}
 			// block until ^C received
-			return d.Start(cmd.Context(), make(chan struct{}))
+			return d.Start(ctx, make(chan struct{}))
 		},
 	}
 	cmd.SetOut(out)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -305,8 +305,6 @@ func New(ctx context.Context, logger logr.Logger, cfg Config) (*Daemon, error) {
 // Start the otfd daemon and block until ctx is cancelled or an error is
 // returned. The started channel is closed once the daemon has started.
 func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
-	// Give superuser privileges to all server processes
-	ctx = otf.AddSubjectToContext(ctx, &otf.Superuser{Username: "app-user"})
 	// Cancel context the first time a func started with g.Go() fails
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/sql/pggen/user.sql.go
+++ b/sql/pggen/user.sql.go
@@ -451,7 +451,7 @@ func (q *DBQuerier) FindUserByAuthenticationTokenIDScan(results pgx.BatchResults
 
 const updateUserSiteAdminsSQL = `UPDATE users
 SET site_admin = true
-WHERE username = ANY($1)
+WHERE username = ANY($1::text[])
 RETURNING username
 ;`
 

--- a/sql/queries/user.sql
+++ b/sql/queries/user.sql
@@ -91,7 +91,7 @@ WHERE t.token_id = pggen.arg('token_id')
 -- name: UpdateUserSiteAdmins :many
 UPDATE users
 SET site_admin = true
-WHERE username = ANY(pggen.arg('usernames'))
+WHERE username = ANY(pggen.arg('usernames')::text[])
 RETURNING username
 ;
 


### PR DESCRIPTION
Any users promoted to site admin, using `--site-admins=`, are, with this PR, now created if they don't exist before being promoted.