### PR TITLE
Fix flaky logs test

### DIFF
--- a/integration/logs_test.go
+++ b/integration/logs_test.go
@@ -47,14 +47,7 @@ func TestLogs(t *testing.T) {
 		err := svc.PutChunk(ctx, otf.PutChunkOptions{
 			RunID: run.ID,
 			Phase: otf.PlanPhase,
-			Data:  []byte("\x02hello"),
-		})
-		require.NoError(t, err)
-
-		err = svc.PutChunk(ctx, otf.PutChunkOptions{
-			RunID: run.ID,
-			Phase: otf.PlanPhase,
-			Data:  []byte(" world\x03"),
+			Data:  []byte("\x02hello world\x03"),
 		})
 		require.NoError(t, err)
 
@@ -64,7 +57,7 @@ func TestLogs(t *testing.T) {
 			want otf.Chunk
 		}{
 			{
-				name: "all chunks",
+				name: "entire chunk",
 				opts: otf.GetChunkOptions{
 					RunID: run.ID,
 					Phase: otf.PlanPhase,

--- a/logs/proxy.go
+++ b/logs/proxy.go
@@ -118,7 +118,7 @@ func (p *proxy) put(ctx context.Context, opts otf.PutChunkOptions) error {
 		Data:   opts.Data,
 		Offset: opts.Offset,
 	}
-	// publish chunk so that other otfd nodes can receive and cache the chunk
+	// publish chunk for caching
 	p.Publish(otf.Event{Type: otf.EventLogChunk, Payload: chunk})
 	return nil
 }


### PR DESCRIPTION
The caching of logs is an asynchronous operation and thus the integration test for retrieval of logs would occasionally receive only the first chunk, and not both as expected. This PR fixes by simply writing a single chunk for the test, since the test in question if testing the retrieval and not the persistence of logs.