### PR TITLE
Fix up state version output API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ go-tfe-tests-forked:
 
 .PHONY: go-tfe-tests-upstream
 go-tfe-tests-upstream:
-	GO_TFE_REPO=github.com/hashicorp/go-tfe@latest ./hack/go-tfe-tests.bash 'Test(OrganizationTags|Workspaces_(Add|Remove)Tags)|TestWorkspacesList/when_searching_using_a_tag'
+	GO_TFE_REPO=github.com/hashicorp/go-tfe@latest ./hack/go-tfe-tests.bash 'Test(OrganizationTags|Workspaces_(Add|Remove)Tags)|TestWorkspacesList/when_searching_using_a_tag|TestStateVersionOutputsRead'
 
 .PHONY: test
 test:

--- a/api/state.go
+++ b/api/state.go
@@ -28,6 +28,7 @@ func (a *api) addStateHandlers(r *mux.Router) {
 	r.HandleFunc("/state-versions/{id}/download", a.downloadState).Methods("GET")
 	r.HandleFunc("/state-versions/{id}", a.deleteVersion).Methods("DELETE")
 
+	r.HandleFunc("/workspaces/{workspace_id}/current-state-version-outputs", a.getCurrentVersionOutputs).Methods("GET")
 	r.HandleFunc("/state-versions/{id}/outputs", a.listOutputs).Methods("GET")
 	r.HandleFunc("/state-version-outputs/{id}", a.getOutput).Methods("GET")
 }
@@ -171,6 +172,22 @@ func (a *api) downloadState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(resp)
+}
+
+func (a *api) getCurrentVersionOutputs(w http.ResponseWriter, r *http.Request) {
+	workspaceID, err := decode.Param("workspace_id", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	sv, err := a.GetCurrentStateVersion(r.Context(), workspaceID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	a.writeResponse(w, r, sv.Outputs)
 }
 
 func (a *api) listOutputs(w http.ResponseWriter, r *http.Request) {

--- a/api/types/state.go
+++ b/api/types/state.go
@@ -27,13 +27,7 @@ type StateVersionOutput struct {
 	Name      string `jsonapi:"attribute" json:"name"`
 	Sensitive bool   `jsonapi:"attribute" json:"sensitive"`
 	Type      string `jsonapi:"attribute" json:"type"`
-	Value     string `jsonapi:"attribute" json:"value"`
-}
-
-// StateVersionOutputList is a list of state version outputs suitable for marshaling into
-// JSONAPI
-type StateVersionOutputList struct {
-	Items []*StateVersionOutput
+	Value     any    `jsonapi:"attribute" json:"value"`
 }
 
 // StateVersionCreateVersionOptions are options for creating a state version via


### PR DESCRIPTION
Fixes #421 

Also:

* fixes marshaling of outputs when included alongside a state version.
* runs latest upstream `go-tfe` API tests against the state version outputs API