### PR TITLE
Use `mktemp` instead of `tempdir`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install:
 install-latest-release:
 	{ \
 	set -ex ;\
-	ZIP_FILE=$$(tempfile --prefix=otf --suffix=.zip) ;\
+	ZIP_FILE=$$(mktemp -t otf) ;\
 	RELEASE_URL=$$(curl -s https://api.github.com/repos/leg100/otf/releases/latest | \
 		jq -r '.assets[] | select(.name | test("otfd_.*_linux_amd64.zip$$")) | .browser_download_url') ;\
 	curl -Lo $$ZIP_FILE $$RELEASE_URL ;\

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install:
 install-latest-release:
 	{ \
 	set -ex ;\
-	ZIP_FILE=$$(mktemp -t otf) ;\
+	ZIP_FILE=$$(mktemp) ;\
 	RELEASE_URL=$$(curl -s https://api.github.com/repos/leg100/otf/releases/latest | \
 		jq -r '.assets[] | select(.name | test("otfd_.*_linux_amd64.zip$$")) | .browser_download_url') ;\
 	curl -Lo $$ZIP_FILE $$RELEASE_URL ;\


### PR DESCRIPTION
fix #427 

This fixes the makefile rule for me on macOS and it also (still) works on Linux.