### PR TITLE
Fix workspace access for unprivileged user

### DIFF
--- a/internal/http/html/static/templates/content/workspace_get.tmpl
+++ b/internal/http/html/static/templates/content/workspace_get.tmpl
@@ -31,7 +31,9 @@
           <select name="strategy" id="start-run-strategy" onchange="this.form.submit()">
             <option value="" selected>-- start run --</option>
             <option value="plan-only">plan only</option>
-            <option value="plan-and-apply">plan and apply</option>
+            {{ if .CanApply }}
+              <option value="plan-and-apply">plan and apply</option>
+            {{ end }}
           </select>
         </form>
       </div>

--- a/internal/integration/organization_min_permissions_test.go
+++ b/internal/integration/organization_min_permissions_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/leg100/otf/internal/auth"
+	"github.com/leg100/otf/internal/rbac"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_MinimumPermissions demonstrates that once a user is
+// indirectly a member of an organization - i.e. they have been assigned at least
+// a role on a workspace in the organization - that they receive a minimum set
+// of permissions across the organization.
+func TestIntegration_MinimumPermissions(t *testing.T) {
+	t.Parallel()
+
+	// Create org and its owner
+	svc := setup(t, nil)
+	_, ownerCtx := svc.createUserCtx(t, ctx)
+	org := svc.createOrganization(t, ownerCtx)
+	ws := svc.createWorkspace(t, ownerCtx, org)
+
+	// Create user and add as member of guests team
+	guest := svc.createUser(t, ctx)
+	guests := svc.createTeam(t, ownerCtx, org)
+	err := svc.AddTeamMembership(ownerCtx, auth.TeamMembershipOptions{
+		TeamID:   guests.ID,
+		Username: guest.Username,
+	})
+	require.NoError(t, err)
+
+	// Assign read role to guests team. Guests now receive a minimum set of
+	// permissions across the workspace's organization.
+	err = svc.SetPermission(ownerCtx, ws.ID, guests.Name, rbac.WorkspaceReadRole)
+	require.NoError(t, err)
+
+	// Now we'll carry out various actions as the guest
+	_, guestCtx := svc.getUserCtx(t, ctx, guest.Username)
+
+	// Guest should be able to get org
+	_, err = svc.GetOrganization(guestCtx, org.Name)
+	require.NoError(t, err)
+
+	// Guest should be able to list teams
+	_, err = svc.ListTeams(guestCtx, org.Name)
+	require.NoError(t, err)
+
+	// Guest should be able to list providers
+	_, err = svc.ListVCSProviders(guestCtx, org.Name)
+	require.NoError(t, err)
+
+	// Guest should be able to get a provider
+	provider := svc.createVCSProvider(t, ownerCtx, org)
+	_, err = svc.GetVCSProvider(guestCtx, provider.ID)
+	require.NoError(t, err)
+}

--- a/internal/integration/plan_permission_e2e_test.go
+++ b/internal/integration/plan_permission_e2e_test.go
@@ -9,17 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPlanPermissionE2E demonstrates a user with plan permissions on a workspace interacting
-// with the workspace via the terraform CLI.
-func TestPlanPermissionE2E(t *testing.T) {
+// TestIntegration_PlanPermission demonstrates the assignment of the workspace
+// 'plan' role to a team and what they can and cannot do with that role via the
+// CLI and via the UI.
+func TestIntegration_PlanPermission(t *testing.T) {
 	t.Parallel()
 
-	// Create user and org, and user becomes owner of the org
+	// Create org and its owner
 	svc := setup(t, nil)
 	owner, ownerCtx := svc.createUserCtx(t, ctx)
 	org := svc.createOrganization(t, ownerCtx)
 
-	// Create engineer user and team and make member of a team
+	// Create user and add as member of engineers team
 	engineer, engineerCtx := svc.createUserCtx(t, ctx)
 	team := svc.createTeam(t, ownerCtx, org)
 	err := svc.AddTeamMembership(ownerCtx, auth.TeamMembershipOptions{
@@ -28,11 +29,11 @@ func TestPlanPermissionE2E(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// create terraform configPath
+	// create some terraform configuration
 	configPath := newRootModule(t, svc.Hostname(), org.Name, "my-test-workspace")
 
-	// Open browser, using owner's credentials create workspace and assign plan
-	// permissions to the engineer's team.
+	// Open browser and using owner's credentials create a workspace and assign plan
+	// role to the engineer's team.
 	browser := createBrowserCtx(t)
 	err = chromedp.Run(browser, chromedp.Tasks{
 		newSession(t, ownerCtx, svc.Hostname(), owner.Username, svc.Secret),
@@ -41,7 +42,8 @@ func TestPlanPermissionE2E(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// As engineer, run terraform init, and plan.
+	// As engineer, run terraform init, and plan. This should succeed because
+	// the engineer has been assigned the plan role.
 	_ = svc.tfcli(t, engineerCtx, "init", configPath)
 	out := svc.tfcli(t, engineerCtx, "plan", configPath)
 	assert.Contains(t, out, "Plan: 1 to add, 0 to change, 0 to destroy.")
@@ -57,4 +59,28 @@ func TestPlanPermissionE2E(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, string(out), "Error: Insufficient rights to apply changes")
 	}
+
+	// Now demonstrate UI access by starting a plan via the UI.
+	err = chromedp.Run(browser, chromedp.Tasks{
+		newSession(t, ctx, svc.Hostname(), engineer.Username, svc.Secret),
+		// go to workspace page
+		chromedp.Navigate(workspaceURL(svc.Hostname(), org.Name, "my-test-workspace")),
+		screenshot(t),
+		// select strategy for run
+		chromedp.SetValue(`//select[@id="start-run-strategy"]`, "plan-only", chromedp.BySearch),
+		screenshot(t),
+		// confirm plan begins and ends
+		chromedp.WaitReady(`body`),
+		chromedp.WaitReady(`//*[@id='tailed-plan-logs']//text()[contains(.,'Initializing the backend')]`, chromedp.BySearch),
+		screenshot(t),
+		chromedp.WaitReady(`#plan-status.phase-status-finished`),
+		screenshot(t),
+		// wait for run to enter planned-and-finished state
+		chromedp.WaitReady(`//*[@id='run-status']//*[normalize-space(text())='planned and finished']`, chromedp.BySearch),
+		screenshot(t),
+		// run widget should show plan summary
+		matchRegex(t, `//div[@class='item']//div[@class='resource-summary']`, `\+[0-9]+ \~[0-9]+ \-[0-9]+`),
+		screenshot(t),
+	})
+	require.NoError(t, err)
 }

--- a/internal/integration/test_daemon.go
+++ b/internal/integration/test_daemon.go
@@ -207,6 +207,14 @@ func (s *testDaemon) getUser(t *testing.T, ctx context.Context, username string)
 	return user
 }
 
+func (s *testDaemon) getUserCtx(t *testing.T, ctx context.Context, username string) (*auth.User, context.Context) {
+	t.Helper()
+
+	user, err := s.GetUser(ctx, auth.UserSpec{Username: &username})
+	require.NoError(t, err)
+	return user, internal.AddSubjectToContext(ctx, user)
+}
+
 func (s *testDaemon) createTeam(t *testing.T, ctx context.Context, org *organization.Organization) *auth.Team {
 	t.Helper()
 

--- a/internal/rbac/role.go
+++ b/internal/rbac/role.go
@@ -9,14 +9,16 @@ var (
 	OrganizationMinPermissions = Role{
 		name: "minimum",
 		permissions: map[Action]bool{
-			GetOrganizationAction: true,
-			GetEntitlementsAction: true,
-			ListModulesAction:     true,
-			GetModuleAction:       true,
-			GetTeamAction:         true,
-			ListTeamsAction:       true,
-			ListUsersAction:       true,
-			ListTagsAction:        true,
+			GetOrganizationAction:  true,
+			GetEntitlementsAction:  true,
+			ListModulesAction:      true,
+			GetModuleAction:        true,
+			GetTeamAction:          true,
+			ListTeamsAction:        true,
+			ListUsersAction:        true,
+			ListTagsAction:         true,
+			ListVCSProvidersAction: true,
+			GetVCSProviderAction:   true,
 		},
 	}
 
@@ -37,6 +39,7 @@ var (
 			GetVariableAction:                  true,
 			WatchAction:                        true,
 			ListWorkspaceTags:                  true,
+			TailLogsAction:                     true,
 		},
 	}
 

--- a/internal/workspace/web.go
+++ b/internal/workspace/web.go
@@ -187,10 +187,12 @@ func (h *webHandlers) getWorkspace(w http.ResponseWriter, r *http.Request) {
 		WorkspacePage
 		LockButton
 		VCSProvider *vcsprovider.VCSProvider
+		CanApply    bool
 	}{
 		WorkspacePage: NewPage(r, ws.ID, ws),
 		LockButton:    lockButtonHelper(ws, policy, user),
 		VCSProvider:   provider,
+		CanApply:      user.CanAccessWorkspace(rbac.ApplyRunAction, policy),
 	})
 }
 


### PR DESCRIPTION
Fixes #426 and addresses a few other issues for users with limited privileges:

* Removes the option to "plan and apply" a run from the UI for a user who can only plan a run.
* Adds some tests demonstrating a user receives miminum permissions across an organization
* A user with the read role can now tail a run, so they see logs in real time via the UI