### PR TITLE
fix: webhook updates

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -4,86 +4,84 @@ import (
 	"context"
 )
 
-type Client interface {
-	GetUser(ctx context.Context) (*User, error)
-	// ListRepositories lists repositories accessible to the current user.
-	ListRepositories(ctx context.Context, opts ListRepositoriesOptions) ([]string, error)
-	GetRepository(ctx context.Context, identifier string) (string, error)
-	// GetRepoTarball retrieves a .tar.gz tarball of a git repository
-	GetRepoTarball(ctx context.Context, opts GetRepoTarballOptions) ([]byte, error)
-	// CreateWebhook creates a webhook on the cloud provider, returning the
-	// provider's unique ID for the webhook.
-	CreateWebhook(ctx context.Context, opts CreateWebhookOptions) (string, error)
-	UpdateWebhook(ctx context.Context, opts UpdateWebhookOptions) error
-	GetWebhook(ctx context.Context, opts GetWebhookOptions) (Webhook, error)
-	DeleteWebhook(ctx context.Context, opts DeleteWebhookOptions) error
-	SetStatus(ctx context.Context, opts SetStatusOptions) error
-	// ListTags lists git tags on a repository. Each tag should be prefixed with
-	// 'tags/'.
-	ListTags(ctx context.Context, opts ListTagsOptions) ([]string, error)
-}
+type (
+	Client interface {
+		GetUser(ctx context.Context) (*User, error)
+		// ListRepositories lists repositories accessible to the current user.
+		ListRepositories(ctx context.Context, opts ListRepositoriesOptions) ([]string, error)
+		GetRepository(ctx context.Context, identifier string) (string, error)
+		// GetRepoTarball retrieves a .tar.gz tarball of a git repository
+		GetRepoTarball(ctx context.Context, opts GetRepoTarballOptions) ([]byte, error)
+		// CreateWebhook creates a webhook on the cloud provider, returning the
+		// provider's unique ID for the webhook.
+		CreateWebhook(ctx context.Context, opts CreateWebhookOptions) (string, error)
+		UpdateWebhook(ctx context.Context, id string, opts UpdateWebhookOptions) error
+		GetWebhook(ctx context.Context, opts GetWebhookOptions) (Webhook, error)
+		DeleteWebhook(ctx context.Context, opts DeleteWebhookOptions) error
+		SetStatus(ctx context.Context, opts SetStatusOptions) error
+		// ListTags lists git tags on a repository. Each tag should be prefixed with
+		// 'tags/'.
+		ListTags(ctx context.Context, opts ListTagsOptions) ([]string, error)
+	}
 
-// ClientOptions are options for constructing a cloud client
-type ClientOptions struct {
-	Hostname            string
-	SkipTLSVerification bool
-	Credentials
-}
+	// ClientOptions are options for constructing a cloud client
+	ClientOptions struct {
+		Hostname            string
+		SkipTLSVerification bool
+		Credentials
+	}
 
-type GetRepoTarballOptions struct {
-	Repo string  // repo identifier, <owner>/<repo>
-	Ref  *string // branch/tag/SHA ref, nil means default branch
-}
+	GetRepoTarballOptions struct {
+		Repo string  // repo identifier, <owner>/<repo>
+		Ref  *string // branch/tag/SHA ref, nil means default branch
+	}
 
-type ListRepositoriesOptions struct {
-	PageSize int
-}
+	ListRepositoriesOptions struct {
+		PageSize int
+	}
 
-// ListTagsOptions are options for listing tags on a vcs repository
-type ListTagsOptions struct {
-	Repo   string // repo identifier, <owner>/<repo>
-	Prefix string // only list tags that start with this string
-}
+	// ListTagsOptions are options for listing tags on a vcs repository
+	ListTagsOptions struct {
+		Repo   string // repo identifier, <owner>/<repo>
+		Prefix string // only list tags that start with this string
+	}
 
-// Webhook is a cloud's configuration for a webhook.
-type Webhook struct {
-	ID       string // cloud's webhook ID
-	Repo     string // identifier is <repo_owner>/<repo_name>
-	Events   []VCSEventType
-	Endpoint string // the OTF URL that receives events
-}
+	// Webhook is a cloud's configuration for a webhook.
+	Webhook struct {
+		ID       string // cloud's webhook ID
+		Repo     string // identifier is <repo_owner>/<repo_name>
+		Events   []VCSEventType
+		Endpoint string // the OTF URL that receives events
+	}
 
-type CreateWebhookOptions struct {
-	Repo     string // repo identifier, <owner>/<repo>
-	Secret   string // secret string for generating signature
-	Endpoint string // otf's external-facing host[:port]
-	Events   []VCSEventType
-}
+	CreateWebhookOptions struct {
+		Repo     string // repo identifier, <owner>/<repo>
+		Secret   string // secret string for generating signature
+		Endpoint string // otf's external-facing host[:port]
+		Events   []VCSEventType
+	}
 
-type UpdateWebhookOptions struct {
-	ID string // vcs' webhook ID
+	UpdateWebhookOptions CreateWebhookOptions
 
-	CreateWebhookOptions
-}
+	// GetWebhookOptions are options for retrieving a webhook.
+	GetWebhookOptions struct {
+		Repo string // Repository identifier, <owner>/<repo>
+		ID   string // vcs' webhook ID
+	}
 
-// GetWebhookOptions are options for retrieving a webhook.
-type GetWebhookOptions struct {
-	Repo string // Repository identifier, <owner>/<repo>
-	ID   string // vcs' webhook ID
-}
+	// DeleteWebhookOptions are options for deleting a webhook.
+	DeleteWebhookOptions struct {
+		Repo string // Repository identifier, <owner>/<repo>
+		ID   string // vcs' webhook ID
+	}
 
-// DeleteWebhookOptions are options for deleting a webhook.
-type DeleteWebhookOptions struct {
-	Repo string // Repository identifier, <owner>/<repo>
-	ID   string // vcs' webhook ID
-}
-
-// SetStatusOptions are options for setting a status on a VCS repo
-type SetStatusOptions struct {
-	Workspace   string // workspace name
-	Repo        string // <owner>/<repo>
-	Ref         string // git ref
-	Status      VCSStatus
-	TargetURL   string
-	Description string
-}
+	// SetStatusOptions are options for setting a status on a VCS repo
+	SetStatusOptions struct {
+		Workspace   string // workspace name
+		Repo        string // <owner>/<repo>
+		Ref         string // git ref
+		Status      VCSStatus
+		TargetURL   string
+		Description string
+	}
+)

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -195,8 +195,8 @@ func (g *Client) CreateWebhook(ctx context.Context, opts cloud.CreateWebhookOpti
 	return strconv.Itoa(hook.ID), nil
 }
 
-func (g *Client) UpdateWebhook(ctx context.Context, opts cloud.UpdateWebhookOptions) error {
-	id, err := strconv.Atoi(opts.ID)
+func (g *Client) UpdateWebhook(ctx context.Context, id string, opts cloud.UpdateWebhookOptions) error {
+	intID, err := strconv.Atoi(id)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func (g *Client) UpdateWebhook(ctx context.Context, opts cloud.UpdateWebhookOpti
 		}
 	}
 
-	_, _, err = g.client.Projects.EditProjectHook(opts.Repo, id, editOpts)
+	_, _, err = g.client.Projects.EditProjectHook(opts.Repo, intID, editOpts)
 	if err != nil {
 		return err
 	}

--- a/internal/repo/hook.go
+++ b/internal/repo/hook.go
@@ -1,14 +1,9 @@
 package repo
 
 import (
-	"context"
-	"reflect"
-
-	"github.com/pkg/errors"
-
 	"github.com/google/uuid"
-	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/cloud"
+	"golang.org/x/exp/slog"
 )
 
 // defaultEvents are the VCS events that hooks subscribe to.
@@ -20,7 +15,7 @@ var defaultEvents = []cloud.VCSEventType{
 // hook is a webhook for a VCS repo
 type hook struct {
 	id      uuid.UUID // internal otf ID
-	cloudID *string   // cloud's hook ID, populated following synchronisation
+	cloudID *string   // cloud's hook ID; populated following synchronisation
 
 	secret     string // secret token
 	identifier string // repo identifier: <repo_owner>/<repo_name>
@@ -30,56 +25,15 @@ type hook struct {
 	cloud.EventHandler // handles incoming vcs events
 }
 
-// sync synchronises a hook with the cloud
-func (h *hook) sync(ctx context.Context, client cloud.Client) error {
-	if h.cloudID == nil {
-		cloudID, err := client.CreateWebhook(ctx, h.createOpts())
-		if err != nil {
-			return err
-		}
-		h.cloudID = &cloudID
-		return nil
+func (h *hook) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.String("id", h.id.String()),
+		slog.String("cloud", h.cloud),
+		slog.String("repo", h.identifier),
+		slog.String("endpoint", h.endpoint),
 	}
-
-	// existing hook in DB; check it exists in cloud and create/update
-	// accordingly
-	cloudHook, err := client.GetWebhook(ctx, cloud.GetWebhookOptions{
-		Repo: h.identifier,
-		ID:   *h.cloudID,
-	})
-	if errors.Is(err, internal.ErrResourceNotFound) {
-		// hook not found in cloud; create it
-		cloudID, err := client.CreateWebhook(ctx, h.createOpts())
-		if err != nil {
-			return err
-		}
-		h.cloudID = &cloudID
-		return nil
-	} else if err != nil {
-		return errors.Wrap(err, "retrieving config from cloud")
+	if h.cloudID != nil {
+		attrs = append(attrs, slog.String("vcs_id", *h.cloudID))
 	}
-
-	// hook found in both DB and on cloud; check for differences and update
-	// accordingly
-	if reflect.DeepEqual(defaultEvents, cloudHook.Events) &&
-		h.endpoint == cloudHook.Endpoint {
-		// no differences
-		return nil
-	}
-
-	// differences found; update hook on cloud
-	err = client.UpdateWebhook(ctx, cloud.UpdateWebhookOptions{
-		ID:                   cloudHook.ID,
-		CreateWebhookOptions: h.createOpts(),
-	})
-	return err
-}
-
-func (h *hook) createOpts() cloud.CreateWebhookOptions {
-	return cloud.CreateWebhookOptions{
-		Repo:     h.identifier,
-		Secret:   h.secret,
-		Events:   defaultEvents,
-		Endpoint: h.endpoint,
-	}
+	return slog.GroupValue(attrs...)
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -33,4 +33,9 @@ type (
 		ResourceID string      // ID of OTF resource
 		Tx         internal.DB // Optional tx for performing database ops within.
 	}
+
+	SynchroniseOptions struct {
+		VCSProviderID string // vcs provider of repo
+		RepoPath      string
+	}
 )

--- a/internal/repo/synchroniser.go
+++ b/internal/repo/synchroniser.go
@@ -1,0 +1,69 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/leg100/otf/internal"
+	"github.com/leg100/otf/internal/cloud"
+	"github.com/pkg/errors"
+)
+
+type (
+	// synchroniser synchronises a hook with the vcs provider
+	synchroniser struct {
+		logr.Logger
+	}
+
+	db interface {
+		getHookByIDForUpdate(ctx context.Context, id uuid.UUID) (*hook, error)
+		updateHookCloudID(ctx context.Context, id uuid.UUID, cloudID string) error
+	}
+)
+
+// sync should be called from within a tx to avoid inconsistent results.
+func (s *synchroniser) sync(ctx context.Context, db db, client cloud.Client, hook *hook) error {
+	createAndSync := func() error {
+		cloudID, err := client.CreateWebhook(ctx, cloud.CreateWebhookOptions{
+			Repo:     hook.identifier,
+			Secret:   hook.secret,
+			Events:   defaultEvents,
+			Endpoint: hook.endpoint,
+		})
+		if err != nil {
+			return err
+		}
+		s.Info("created webhook", "webhook", hook)
+		if err := db.updateHookCloudID(ctx, hook.id, cloudID); err != nil {
+			return err
+		}
+		return nil
+	}
+	if hook.cloudID == nil {
+		return createAndSync()
+	}
+	cloudHook, err := client.GetWebhook(ctx, cloud.GetWebhookOptions{
+		Repo: hook.identifier,
+		ID:   *hook.cloudID,
+	})
+	if errors.Is(err, internal.ErrResourceNotFound) {
+		return createAndSync()
+	} else if err != nil {
+		return fmt.Errorf("retrieving hook from cloud: %w", err)
+	}
+	// hook is present on the vcs repo, but we update it anyway just to ensure
+	// its configuration is consistent with what we have in the DB
+	err = client.UpdateWebhook(ctx, cloudHook.ID, cloud.UpdateWebhookOptions{
+		Repo:     hook.identifier,
+		Secret:   hook.secret,
+		Events:   defaultEvents,
+		Endpoint: hook.endpoint,
+	})
+	if err != nil {
+		return err
+	}
+	s.Info("updated webhook", "webhook", hook)
+	return nil
+}

--- a/internal/repo/test_helpers.go
+++ b/internal/repo/test_helpers.go
@@ -13,6 +13,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type (
+	fakeCloudService struct {
+		event cloud.VCSEvent
+		cloud.Service
+	}
+	fakeCloud struct {
+		event cloud.VCSEvent
+
+		cloud.Cloud
+	}
+	fakeHostnameService struct {
+		hostname string
+
+		internal.HostnameService
+	}
+	fakeCloudClient struct {
+		hook      cloud.Webhook // seed cloud with hook
+		gotUpdate bool
+
+		cloud.Client
+	}
+	fakeDB struct {
+		hook *hook
+	}
+)
+
 func newTestHook(t *testing.T, f factory, cloudID *string) *hook {
 	want, err := f.newHook(newHookOpts{
 		id:         internal.UUID(uuid.New()),
@@ -49,39 +75,15 @@ func newTestDB(t *testing.T) *pgdb {
 	}
 }
 
-type fakeCloudService struct {
-	event cloud.VCSEvent
-	cloud.Service
-}
-
 func (f fakeCloudService) GetCloudConfig(string) (cloud.Config, error) {
 	return cloud.Config{Cloud: &fakeCloud{event: f.event}}, nil
-}
-
-type fakeCloud struct {
-	event cloud.VCSEvent
-
-	cloud.Cloud
 }
 
 func (f *fakeCloud) HandleEvent(http.ResponseWriter, *http.Request, cloud.HandleEventOptions) cloud.VCSEvent {
 	return f.event
 }
 
-type fakeHostnameService struct {
-	hostname string
-
-	internal.HostnameService
-}
-
 func (f fakeHostnameService) Hostname() string { return f.hostname }
-
-type fakeCloudClient struct {
-	hook      cloud.Webhook // seed cloud with hook
-	gotUpdate bool
-
-	cloud.Client
-}
 
 func (f *fakeCloudClient) CreateWebhook(context.Context, cloud.CreateWebhookOptions) (string, error) {
 	return f.hook.ID, nil
@@ -94,8 +96,17 @@ func (f *fakeCloudClient) GetWebhook(ctx context.Context, opts cloud.GetWebhookO
 	return cloud.Webhook{}, internal.ErrResourceNotFound
 }
 
-func (f *fakeCloudClient) UpdateWebhook(context.Context, cloud.UpdateWebhookOptions) error {
+func (f *fakeCloudClient) UpdateWebhook(context.Context, string, cloud.UpdateWebhookOptions) error {
 	f.gotUpdate = true
 
+	return nil
+}
+
+func (f *fakeDB) getHookByIDForUpdate(ctx context.Context, id uuid.UUID) (*hook, error) {
+	return f.hook, nil
+}
+
+func (f *fakeDB) updateHookCloudID(ctx context.Context, id uuid.UUID, cloudID string) error {
+	f.hook.cloudID = &cloudID
 	return nil
 }

--- a/internal/sql/pggen/agent_token.sql.go
+++ b/internal/sql/pggen/agent_token.sql.go
@@ -944,12 +944,26 @@ type Querier interface {
 	// FindWebhookByIDScan scans the result of an executed FindWebhookByIDBatch query.
 	FindWebhookByIDScan(results pgx.BatchResults) (FindWebhookByIDRow, error)
 
-	FindWebhooksByRepo(ctx context.Context, identifier pgtype.Text, cloud pgtype.Text) ([]FindWebhooksByRepoRow, error)
-	// FindWebhooksByRepoBatch enqueues a FindWebhooksByRepo query into batch to be executed
+	FindWebhookByIDForUpdate(ctx context.Context, webhookID pgtype.UUID) (FindWebhookByIDForUpdateRow, error)
+	// FindWebhookByIDForUpdateBatch enqueues a FindWebhookByIDForUpdate query into batch to be executed
 	// later by the batch.
-	FindWebhooksByRepoBatch(batch genericBatch, identifier pgtype.Text, cloud pgtype.Text)
-	// FindWebhooksByRepoScan scans the result of an executed FindWebhooksByRepoBatch query.
-	FindWebhooksByRepoScan(results pgx.BatchResults) ([]FindWebhooksByRepoRow, error)
+	FindWebhookByIDForUpdateBatch(batch genericBatch, webhookID pgtype.UUID)
+	// FindWebhookByIDForUpdateScan scans the result of an executed FindWebhookByIDForUpdateBatch query.
+	FindWebhookByIDForUpdateScan(results pgx.BatchResults) (FindWebhookByIDForUpdateRow, error)
+
+	FindWebhookByRepoForUpdate(ctx context.Context, identifier pgtype.Text, cloud pgtype.Text) (FindWebhookByRepoForUpdateRow, error)
+	// FindWebhookByRepoForUpdateBatch enqueues a FindWebhookByRepoForUpdate query into batch to be executed
+	// later by the batch.
+	FindWebhookByRepoForUpdateBatch(batch genericBatch, identifier pgtype.Text, cloud pgtype.Text)
+	// FindWebhookByRepoForUpdateScan scans the result of an executed FindWebhookByRepoForUpdateBatch query.
+	FindWebhookByRepoForUpdateScan(results pgx.BatchResults) (FindWebhookByRepoForUpdateRow, error)
+
+	FindWebhookByRepo(ctx context.Context, identifier pgtype.Text, cloud pgtype.Text) ([]FindWebhookByRepoRow, error)
+	// FindWebhookByRepoBatch enqueues a FindWebhookByRepo query into batch to be executed
+	// later by the batch.
+	FindWebhookByRepoBatch(batch genericBatch, identifier pgtype.Text, cloud pgtype.Text)
+	// FindWebhookByRepoScan scans the result of an executed FindWebhookByRepoBatch query.
+	FindWebhookByRepoScan(results pgx.BatchResults) ([]FindWebhookByRepoRow, error)
 
 	DeleteWebhookByID(ctx context.Context, webhookID pgtype.UUID) (DeleteWebhookByIDRow, error)
 	// DeleteWebhookByIDBatch enqueues a DeleteWebhookByID query into batch to be executed
@@ -1546,8 +1560,14 @@ func PrepareAllQueries(ctx context.Context, p preparer) error {
 	if _, err := p.Prepare(ctx, findWebhookByIDSQL, findWebhookByIDSQL); err != nil {
 		return fmt.Errorf("prepare query 'FindWebhookByID': %w", err)
 	}
-	if _, err := p.Prepare(ctx, findWebhooksByRepoSQL, findWebhooksByRepoSQL); err != nil {
-		return fmt.Errorf("prepare query 'FindWebhooksByRepo': %w", err)
+	if _, err := p.Prepare(ctx, findWebhookByIDForUpdateSQL, findWebhookByIDForUpdateSQL); err != nil {
+		return fmt.Errorf("prepare query 'FindWebhookByIDForUpdate': %w", err)
+	}
+	if _, err := p.Prepare(ctx, findWebhookByRepoForUpdateSQL, findWebhookByRepoForUpdateSQL); err != nil {
+		return fmt.Errorf("prepare query 'FindWebhookByRepoForUpdate': %w", err)
+	}
+	if _, err := p.Prepare(ctx, findWebhookByRepoSQL, findWebhookByRepoSQL); err != nil {
+		return fmt.Errorf("prepare query 'FindWebhookByRepo': %w", err)
 	}
 	if _, err := p.Prepare(ctx, deleteWebhookByIDSQL, deleteWebhookByIDSQL); err != nil {
 		return fmt.Errorf("prepare query 'DeleteWebhookByID': %w", err)

--- a/internal/sql/queries/webhook.sql
+++ b/internal/sql/queries/webhook.sql
@@ -27,7 +27,20 @@ SELECT *
 FROM webhooks
 WHERE webhook_id = pggen.arg('webhook_id');
 
--- name: FindWebhooksByRepo :many
+-- name: FindWebhookByIDForUpdate :one
+SELECT *
+FROM webhooks
+WHERE webhook_id = pggen.arg('webhook_id')
+FOR UPDATE;
+
+-- name: FindWebhookByRepoForUpdate :one
+SELECT *
+FROM webhooks
+WHERE identifier = pggen.arg('identifier')
+AND   cloud = pggen.arg('cloud')
+FOR UPDATE;
+
+-- name: FindWebhookByRepo :many
 SELECT *
 FROM webhooks
 WHERE identifier = pggen.arg('identifier')

--- a/internal/workspace/service.go
+++ b/internal/workspace/service.go
@@ -319,8 +319,7 @@ func (s *service) disconnect(ctx context.Context, workspaceID string) error {
 		ConnectionType: repo.WorkspaceConnection,
 		ResourceID:     workspaceID,
 	})
-	// ignore warnings; the repo is still disconnected successfully
-	if err != nil && !errors.Is(err, internal.ErrWarning) {
+	if err != nil {
 		s.Error(err, "disconnecting workspace", "workspace", workspaceID, "subject", subject)
 		return err
 	}

--- a/internal/workspace/tag_db.go
+++ b/internal/workspace/tag_db.go
@@ -163,7 +163,7 @@ func (db *pgdb) listWorkspaceTags(ctx context.Context, workspaceID string, opts 
 // caller can use the transaction.
 func (db *pgdb) lockTags(ctx context.Context, callback func(*pgdb) error) error {
 	return db.Tx(ctx, func(tx internal.DB) error {
-		if _, err := tx.Exec(ctx, "LOCK tags"); err != nil {
+		if _, err := tx.Exec(ctx, "LOCK TABLE tags IN EXCLUSIVE MODE"); err != nil {
 			return err
 		}
 		return callback(&pgdb{tx})


### PR DESCRIPTION
Fixes a couple of issues with webhooks. Upon "connecting" a workspace with a repo, OTF checks to see if a webhook is already configured for the repo, and if so, it checks for any discrepancies in its configuration, and if there are discrepancies then it updates the webhook configuration to bring into sync with what OTF has. However, that code had a bug where even though the configuration was ok it would flag up a discrepancy and so the webhook would always be updated.

Secondly, the Github client code for updating a webhook would neglect to set all the required parameters. Specifically, it neglected to set the "content-type" of the webhook payload, and thus Github would revert to its default, `form`, whereas OTF requires it to be set to `json`.

This fix does two things:
1. Don't check for discrepancies in webhook config; instead **always** update the webhook whenever a workspace (or module) is connected to a repo. This also ensures any out-of-band alterations to the webhook configuration on the repo are reverted.
2. Fix the Github client code to set the content-type when updating a webhook.