### PR TITLE
fix: caching failures are non-fatal

### DIFF
--- a/internal/configversion/tarball_service.go
+++ b/internal/configversion/tarball_service.go
@@ -24,7 +24,7 @@ func (s *service) UploadConfig(ctx context.Context, cvID string, config []byte) 
 		return err
 	}
 	if err := s.cache.Set(cacheKey(cvID), config); err != nil {
-		return fmt.Errorf("caching configuration version tarball: %w", err)
+		s.Error(err, "caching configuration version tarball")
 	}
 	s.V(2).Info("uploaded configuration", "id", cvID, "bytes", len(config))
 	return nil
@@ -45,7 +45,7 @@ func (s *service) DownloadConfig(ctx context.Context, cvID string) ([]byte, erro
 		return nil, err
 	}
 	if err := s.cache.Set(cacheKey(cvID), config); err != nil {
-		return nil, fmt.Errorf("caching configuration version tarball: %w", err)
+		s.Error(err, "caching configuration version tarball")
 	}
 	s.V(9).Info("downloaded configuration", "id", cvID, "bytes", len(config), "subject", subject)
 	return config, nil

--- a/internal/inmem/cache.go
+++ b/internal/inmem/cache.go
@@ -23,7 +23,7 @@ func NewCache(config CacheConfig) (*bigcache.BigCache, error) {
 	}
 
 	if config.Size != 0 {
-		defaults.HardMaxCacheSize = config.Size
+		defaults.HardMaxCacheSize = config.Size / defaults.Shards
 	}
 
 	cache, err := bigcache.NewBigCache(defaults)

--- a/internal/logs/proxy.go
+++ b/internal/logs/proxy.go
@@ -95,7 +95,7 @@ func (p *proxy) get(ctx context.Context, opts internal.GetChunkOptions) (interna
 		}
 		// ...and cache it
 		if err := p.cache.Set(key, data); err != nil {
-			return internal.Chunk{}, err
+			p.Error(err, "caching log chunk")
 		}
 	}
 	chunk := internal.Chunk{RunID: opts.RunID, Phase: opts.Phase, Data: data}

--- a/internal/run/lock_file_service.go
+++ b/internal/run/lock_file_service.go
@@ -37,7 +37,7 @@ func (s *service) GetLockFile(ctx context.Context, runID string) ([]byte, error)
 
 	// cache lock file before returning
 	if err := s.cache.Set(lockFileCacheKey(runID), file); err != nil {
-		return nil, fmt.Errorf("caching lock file: %w", err)
+		s.Error(err, "caching lock file")
 	}
 	return file, nil
 }
@@ -57,7 +57,7 @@ func (s *service) UploadLockFile(ctx context.Context, runID string, file []byte)
 
 	// cache lock file before returning
 	if err := s.cache.Set(lockFileCacheKey(runID), file); err != nil {
-		return fmt.Errorf("caching plan: %w", err)
+		s.Error(err, "caching lock file")
 	}
 	return nil
 }

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -497,7 +497,7 @@ func (s *service) GetPlanFile(ctx context.Context, runID string, format PlanForm
 	}
 	// Cache plan before returning
 	if err := s.cache.Set(planFileCacheKey(format, runID), file); err != nil {
-		return nil, fmt.Errorf("caching plan: %w", err)
+		s.Error(err, "caching plan file")
 	}
 	return file, nil
 }
@@ -518,7 +518,7 @@ func (s *service) UploadPlanFile(ctx context.Context, runID string, plan []byte,
 	s.V(1).Info("uploaded plan file", "id", runID, "format", format, "subject", subject)
 
 	if err := s.cache.Set(planFileCacheKey(format, runID), plan); err != nil {
-		return fmt.Errorf("caching plan: %w", err)
+		s.Error(err, "caching plan file")
 	}
 
 	return nil

--- a/internal/state/service.go
+++ b/internal/state/service.go
@@ -100,7 +100,7 @@ func (a *service) CreateStateVersion(ctx context.Context, opts CreateStateVersio
 	}
 
 	if err := a.cache.Set(cacheKey(sv.ID), sv.State); err != nil {
-		return nil, fmt.Errorf("caching state file: %w", err)
+		a.Error(err, "caching state file")
 	}
 
 	a.V(0).Info("created state version", "id", sv.ID, "workspace", *opts.WorkspaceID, "serial", sv.Serial, "subject", subject)
@@ -210,7 +210,7 @@ func (a *service) DownloadState(ctx context.Context, svID string) ([]byte, error
 		return nil, err
 	}
 	if err := a.cache.Set(cacheKey(svID), state); err != nil {
-		return nil, fmt.Errorf("caching state: %w", err)
+		a.Error(err, "caching state file")
 	}
 	a.V(9).Info("downloaded state", "id", svID, "subject", subject)
 	return state, nil


### PR DESCRIPTION
If the cache fails for whatever reason it should not be a fatal error, i.e. it should not stop the terraform operation from proceeding.

Fixes #453 