### PR TITLE
feat: support creating plan-only runs

### DIFF
--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -71,6 +71,7 @@ func (a *api) createRun(w http.ResponseWriter, r *http.Request) {
 		ConfigurationVersionID: configurationVersionID,
 		TargetAddrs:            opts.TargetAddrs,
 		ReplaceAddrs:           opts.ReplaceAddrs,
+		PlanOnly:               opts.PlanOnly,
 	})
 	if err != nil {
 		Error(w, err)

--- a/internal/api/types/run.go
+++ b/internal/api/types/run.go
@@ -81,6 +81,9 @@ type RunCreateOptions struct {
 	// set.  https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,runs"`
 
+	// PlanOnly specifies if this is a speculative, plan-only run that Terraform cannot apply.
+	PlanOnly *bool `jsonapi:"attr,plan-only,omitempty"`
+
 	// Specifies if this plan is a destroy plan, which will destroy all
 	// provisioned resources.
 	IsDestroy *bool `jsonapi:"attribute" json:"is-destroy,omitempty"`

--- a/internal/configversion/service.go
+++ b/internal/configversion/service.go
@@ -15,9 +15,6 @@ type (
 
 	Service interface {
 		CreateConfigurationVersion(ctx context.Context, workspaceID string, opts ConfigurationVersionCreateOptions) (*ConfigurationVersion, error)
-		// CloneConfigurationVersion creates a new configuration version using the
-		// config tarball of an existing configuration version.
-		CloneConfigurationVersion(ctx context.Context, cvID string, opts ConfigurationVersionCreateOptions) (*ConfigurationVersion, error)
 		GetConfigurationVersion(ctx context.Context, id string) (*ConfigurationVersion, error)
 		GetLatestConfigurationVersion(ctx context.Context, workspaceID string) (*ConfigurationVersion, error)
 		ListConfigurationVersions(ctx context.Context, workspaceID string, opts ConfigurationVersionListOptions) (*ConfigurationVersionList, error)
@@ -81,29 +78,6 @@ func (s *service) CreateConfigurationVersion(ctx context.Context, workspaceID st
 		return nil, err
 	}
 	s.V(1).Info("created configuration version", "id", cv.ID, "subject", subject)
-	return cv, nil
-}
-
-func (s *service) CloneConfigurationVersion(ctx context.Context, cvID string, opts ConfigurationVersionCreateOptions) (*ConfigurationVersion, error) {
-	cv, err := s.GetConfigurationVersion(ctx, cvID)
-	if err != nil {
-		return nil, err
-	}
-
-	cv, err = s.CreateConfigurationVersion(ctx, cv.WorkspaceID, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := s.DownloadConfig(ctx, cvID)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.UploadConfig(ctx, cv.ID, config); err != nil {
-		return nil, err
-	}
-
 	return cv, nil
 }
 

--- a/internal/http/html/static/templates/content/workspace_edit.tmpl
+++ b/internal/http/html/static/templates/content/workspace_edit.tmpl
@@ -179,7 +179,7 @@
         <button id="queue-destroy-plan-button" class="delete" {{ insufficient $canCreateRun }} onclick="return confirm('This will destroy all infrastructure in this workspace. Please confirm.')">
           Queue destroy plan
         </button>
-        <input name="strategy" value="destroy-all" type="hidden">
+        <input name="operation" value="destroy-all" type="hidden">
       </form>
       <form action="{{ deleteWorkspacePath .Workspace.ID }}" method="POST">
         <button id="delete-workspace-button" class="delete" {{ insufficient $canDelete }} onclick="return confirm('Are you sure you want to delete?')">

--- a/internal/http/html/static/templates/content/workspace_get.tmpl
+++ b/internal/http/html/static/templates/content/workspace_get.tmpl
@@ -30,7 +30,7 @@
       <div class="actions-container">
         <h5>Actions</h5>
         <form id="workspace-start-run-form" action="{{ startRunWorkspacePath .Workspace.ID }}" method="POST">
-          <select name="strategy" id="start-run-strategy" onchange="this.form.submit()">
+          <select name="operation" id="start-run-operation" onchange="this.form.submit()">
             <option value="" selected>-- start run --</option>
             <option value="plan-only">plan only</option>
             {{ if .CanApply }}

--- a/internal/integration/connect_repo_e2e_test.go
+++ b/internal/integration/connect_repo_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/leg100/otf/internal/cloud"
 	"github.com/leg100/otf/internal/github"
+	"github.com/leg100/otf/internal/run"
 	"github.com/leg100/otf/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +35,7 @@ func TestConnectRepoE2E(t *testing.T) {
 		connectWorkspaceTasks(t, daemon.Hostname(), org.Name, "my-test-workspace"),
 		// we can now start a run via the web ui, which'll retrieve the tarball from
 		// the fake github server
-		startRunTasks(t, daemon.Hostname(), org.Name, "my-test-workspace", "plan-and-apply"),
+		startRunTasks(t, daemon.Hostname(), org.Name, "my-test-workspace", run.PlanAndApplyOperation),
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/plan_permission_e2e_test.go
+++ b/internal/integration/plan_permission_e2e_test.go
@@ -66,8 +66,8 @@ func TestIntegration_PlanPermission(t *testing.T) {
 		// go to workspace page
 		chromedp.Navigate(workspaceURL(svc.Hostname(), org.Name, "my-test-workspace")),
 		screenshot(t),
-		// select strategy for run
-		chromedp.SetValue(`//select[@id="start-run-strategy"]`, "plan-only", chromedp.BySearch),
+		// select operation for run
+		chromedp.SetValue(`//select[@id="start-run-operation"]`, "plan-only", chromedp.BySearch),
 		screenshot(t),
 		// confirm plan begins and ends
 		chromedp.WaitReady(`body`),

--- a/internal/integration/run_test.go
+++ b/internal/integration/run_test.go
@@ -145,7 +145,7 @@ func TestRun(t *testing.T) {
 			},
 			{
 				name: "filter out speculative runs in org1",
-				opts: run.RunListOptions{Organization: internal.String(ws1.Organization), Speculative: internal.Bool(false)},
+				opts: run.RunListOptions{Organization: internal.String(ws1.Organization), PlanOnly: internal.Bool(false)},
 				want: func(t *testing.T, l *run.RunList) {
 					// org1 has no speculative runs, so should return both runs
 					assert.Equal(t, 2, len(l.Items))
@@ -154,7 +154,7 @@ func TestRun(t *testing.T) {
 			},
 			{
 				name: "filter out speculative runs in org2",
-				opts: run.RunListOptions{Organization: internal.String(ws2.Organization), Speculative: internal.Bool(false)},
+				opts: run.RunListOptions{Organization: internal.String(ws2.Organization), PlanOnly: internal.Bool(false)},
 				want: func(t *testing.T, l *run.RunList) {
 					// org2 only has speculative runs, so should return zero
 					assert.Equal(t, 0, len(l.Items))

--- a/internal/integration/start_run_ui_test.go
+++ b/internal/integration/start_run_ui_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/chromedp/chromedp"
+	"github.com/leg100/otf/internal/run"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,15 +20,15 @@ func TestStartRunUI(t *testing.T) {
 	_ = svc.createAndUploadConfigurationVersion(t, ctx, ws, nil)
 
 	// now we have a config version, start a run with the plan-and-apply
-	// strategy
+	// operation
 	browser := createBrowserCtx(t)
 	err := chromedp.Run(browser, chromedp.Tasks{
 		newSession(t, ctx, svc.Hostname(), user.Username, svc.Secret),
-		startRunTasks(t, svc.Hostname(), ws.Organization, ws.Name, "plan-and-apply"),
+		startRunTasks(t, svc.Hostname(), ws.Organization, ws.Name, run.PlanAndApplyOperation),
 	})
 	require.NoError(t, err)
 
-	// now destroy resources with the destroy-all strategy
+	// now destroy resources with the destroy-all operation
 	okDialog(t, browser)
 	err = chromedp.Run(browser, chromedp.Tasks{
 		// go to workspace page

--- a/internal/integration/ui_actions.go
+++ b/internal/integration/ui_actions.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"github.com/leg100/otf/internal/run"
 	"github.com/leg100/otf/internal/tokens"
 	"github.com/stretchr/testify/require"
 )
@@ -210,13 +211,13 @@ func createGithubVCSProviderTasks(t *testing.T, hostname, org, name string) chro
 }
 
 // startRunTasks starts a run via the UI
-func startRunTasks(t *testing.T, hostname, organization, workspaceName, strategy string) chromedp.Tasks {
+func startRunTasks(t *testing.T, hostname, organization, workspaceName string, op run.Operation) chromedp.Tasks {
 	return []chromedp.Action{
 		// go to workspace page
 		chromedp.Navigate(workspaceURL(hostname, organization, workspaceName)),
 		screenshot(t, "connected_workspace_main_page"),
-		// select strategy for run
-		chromedp.SetValue(`//select[@id="start-run-strategy"]`, strategy, chromedp.BySearch),
+		// select operation for run
+		chromedp.SetValue(`//select[@id="start-run-operation"]`, string(op), chromedp.BySearch),
 		screenshot(t, "run_page_started"),
 		// confirm plan begins and ends
 		chromedp.WaitReady(`body`),

--- a/internal/run/db.go
+++ b/internal/run/db.go
@@ -38,7 +38,7 @@ type (
 		AppliedChanges         *pggen.Report                 `json:"applied_changes"`
 		ConfigurationVersionID pgtype.Text                   `json:"configuration_version_id"`
 		WorkspaceID            pgtype.Text                   `json:"workspace_id"`
-		Speculative            bool                          `json:"speculative"`
+		PlanOnly               bool                          `json:"plan_only"`
 		ExecutionMode          pgtype.Text                   `json:"execution_mode"`
 		Latest                 bool                          `json:"latest"`
 		OrganizationName       pgtype.Text                   `json:"organization_name"`
@@ -200,8 +200,8 @@ func (db *pgdb) ListRuns(ctx context.Context, opts RunListOptions) (*RunList, er
 		statuses = convertStatusSliceToStringSlice(opts.Statuses)
 	}
 	speculative := "%"
-	if opts.Speculative != nil {
-		speculative = strconv.FormatBool(*opts.Speculative)
+	if opts.PlanOnly != nil {
+		speculative = strconv.FormatBool(*opts.PlanOnly)
 	}
 	db.FindRunsBatch(batch, pggen.FindRunsParams{
 		OrganizationNames: []string{organization},
@@ -349,7 +349,7 @@ func (result pgresult) toRun() *Run {
 		ReplaceAddrs:           result.ReplaceAddrs,
 		TargetAddrs:            result.TargetAddrs,
 		AutoApply:              result.AutoApply,
-		Speculative:            result.Speculative,
+		PlanOnly:               result.PlanOnly,
 		ExecutionMode:          workspace.ExecutionMode(result.ExecutionMode.String),
 		Latest:                 result.Latest,
 		Organization:           result.OrganizationName.String,

--- a/internal/run/db.go
+++ b/internal/run/db.go
@@ -62,6 +62,7 @@ func (db *pgdb) CreateRun(ctx context.Context, run *Run) error {
 			ReplaceAddrs:           run.ReplaceAddrs,
 			TargetAddrs:            run.TargetAddrs,
 			AutoApply:              run.AutoApply,
+			PlanOnly:               run.PlanOnly,
 			ConfigurationVersionID: sql.String(run.ConfigurationVersionID),
 			WorkspaceID:            sql.String(run.WorkspaceID),
 		})
@@ -199,16 +200,16 @@ func (db *pgdb) ListRuns(ctx context.Context, opts RunListOptions) (*RunList, er
 	if len(opts.Statuses) > 0 {
 		statuses = convertStatusSliceToStringSlice(opts.Statuses)
 	}
-	speculative := "%"
+	planOnly := "%"
 	if opts.PlanOnly != nil {
-		speculative = strconv.FormatBool(*opts.PlanOnly)
+		planOnly = strconv.FormatBool(*opts.PlanOnly)
 	}
 	db.FindRunsBatch(batch, pggen.FindRunsParams{
 		OrganizationNames: []string{organization},
 		WorkspaceNames:    []string{workspaceName},
 		WorkspaceIds:      []string{workspaceID},
 		Statuses:          statuses,
-		Speculative:       []string{speculative},
+		PlanOnly:          []string{planOnly},
 		Limit:             opts.GetLimit(),
 		Offset:            opts.GetOffset(),
 	})
@@ -217,7 +218,7 @@ func (db *pgdb) ListRuns(ctx context.Context, opts RunListOptions) (*RunList, er
 		WorkspaceNames:    []string{workspaceName},
 		WorkspaceIds:      []string{workspaceID},
 		Statuses:          statuses,
-		Speculative:       []string{speculative},
+		PlanOnly:          []string{planOnly},
 	})
 
 	results := db.SendBatch(ctx, batch)

--- a/internal/run/factory.go
+++ b/internal/run/factory.go
@@ -30,5 +30,5 @@ func (f *factory) NewRun(ctx context.Context, workspaceID string, opts RunCreate
 		return nil, err
 	}
 
-	return NewRun(cv, ws, opts), nil
+	return newRun(cv, ws, opts), nil
 }

--- a/internal/run/factory_test.go
+++ b/internal/run/factory_test.go
@@ -25,7 +25,7 @@ func TestFactory(t *testing.T) {
 
 		assert.Equal(t, internal.RunPending, got.Status)
 		assert.NotZero(t, got.CreatedAt)
-		assert.False(t, got.Speculative)
+		assert.False(t, got.PlanOnly)
 		assert.True(t, got.Refresh)
 		assert.False(t, got.AutoApply)
 	})
@@ -39,7 +39,19 @@ func TestFactory(t *testing.T) {
 		got, err := f.NewRun(ctx, "", RunCreateOptions{})
 		require.NoError(t, err)
 
-		assert.True(t, got.Speculative)
+		assert.True(t, got.PlanOnly)
+	})
+
+	t.Run("plan-only run", func(t *testing.T) {
+		f := testFactory(
+			&workspace.Workspace{},
+			&configversion.ConfigurationVersion{},
+		)
+
+		got, err := f.NewRun(ctx, "", RunCreateOptions{PlanOnly: internal.Bool(true)})
+		require.NoError(t, err)
+
+		assert.True(t, got.PlanOnly)
 	})
 
 	t.Run("workspace auto-apply", func(t *testing.T) {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -41,7 +41,7 @@ type (
 		PositionInQueue        int                     `json:"position_in_queue"`
 		TargetAddrs            []string                `json:"target_addrs"`
 		AutoApply              bool                    `json:"auto_apply"`
-		Speculative            bool                    `json:"speculative"`
+		PlanOnly               bool                    `json:"plan_only"`
 		Status                 internal.RunStatus      `json:"status"`
 		StatusTimestamps       []RunStatusTimestamp    `json:"status_timestamps"`
 		WorkspaceID            string                  `json:"workspace_id"`
@@ -66,7 +66,7 @@ type (
 	}
 
 	// RunCreateOptions represents the options for creating a new run. See
-	// dto.RunCreateOptions for further detail.
+	// api/types/RunCreateOptions for documentation on each field.
 	RunCreateOptions struct {
 		IsDestroy              *bool
 		Refresh                *bool
@@ -76,6 +76,10 @@ type (
 		TargetAddrs            []string
 		ReplaceAddrs           []string
 		AutoApply              *bool
+		// PlanOnly specifies if this is a speculative, plan-only run that
+		// Terraform cannot apply. Takes precedence over whether the
+		// configuration version is marked as speculative or not.
+		PlanOnly *bool
 	}
 
 	// RunListOptions are options for paginating and filtering a list of runs
@@ -89,8 +93,8 @@ type (
 		Organization *string `schema:"organization_name,omitempty"`
 		// Filter by workspace name
 		WorkspaceName *string `schema:"workspace_name,omitempty"`
-		// Filter by speculative or non-speculative
-		Speculative *bool `schema:"-"`
+		// Filter by plan-only runs
+		PlanOnly *bool `schema:"-"`
 		// A list of relations to include. See available resources:
 		// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
 		Include *string `schema:"include,omitempty"`
@@ -103,8 +107,8 @@ type (
 	}
 )
 
-// NewRun creates a new run with defaults.
-func NewRun(cv *configversion.ConfigurationVersion, ws *workspace.Workspace, opts RunCreateOptions) *Run {
+// newRun creates a new run with defaults.
+func newRun(cv *configversion.ConfigurationVersion, ws *workspace.Workspace, opts RunCreateOptions) *Run {
 	run := Run{
 		ID:                     internal.NewID("run"),
 		CreatedAt:              internal.CurrentTimestamp(),
@@ -112,7 +116,7 @@ func NewRun(cv *configversion.ConfigurationVersion, ws *workspace.Workspace, opt
 		Organization:           ws.Organization,
 		ConfigurationVersionID: cv.ID,
 		WorkspaceID:            ws.ID,
-		Speculative:            cv.Speculative,
+		PlanOnly:               cv.Speculative,
 		ReplaceAddrs:           opts.ReplaceAddrs,
 		TargetAddrs:            opts.TargetAddrs,
 		ExecutionMode:          ws.ExecutionMode,
@@ -134,6 +138,9 @@ func NewRun(cv *configversion.ConfigurationVersion, ws *workspace.Workspace, opt
 	if opts.AutoApply != nil {
 		run.AutoApply = *opts.AutoApply
 	}
+	if opts.PlanOnly != nil {
+		run.PlanOnly = *opts.PlanOnly
+	}
 	if cv.IngressAttributes != nil {
 		run.Commit = &cv.IngressAttributes.CommitSHA
 	}
@@ -146,10 +153,6 @@ func (r *Run) Queued() bool {
 
 func (r *Run) HasChanges() bool {
 	return r.Plan.HasChanges()
-}
-
-func (r *Run) PlanOnly() bool {
-	return r.Status == internal.RunPlannedAndFinished
 }
 
 // HasApply determines whether the run has started applying yet.
@@ -322,7 +325,7 @@ func (r *Run) Finish(phase internal.PhaseType, opts PhaseFinishOptions) error {
 		r.updateStatus(internal.RunPlanned)
 		r.Plan.UpdateStatus(PhaseFinished)
 
-		if !r.HasChanges() || r.Speculative {
+		if !r.HasChanges() || r.PlanOnly {
 			r.updateStatus(internal.RunPlannedAndFinished)
 			r.Apply.UpdateStatus(PhaseUnreachable)
 		} else if r.AutoApply {

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRun_States(t *testing.T) {
 	t.Run("pending", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 
 		require.Equal(t, internal.RunPending, run.Status)
 		require.Equal(t, PhasePending, run.Plan.Status)
@@ -20,7 +20,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("enqueue plan", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 
 		require.NoError(t, run.EnqueuePlan())
 
@@ -30,7 +30,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("start plan", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunPlanQueued
 
 		require.NoError(t, run.Start(internal.PlanPhase))
@@ -41,7 +41,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish plan", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunPlanning
 
 		require.NoError(t, run.Finish(internal.PlanPhase, PhaseFinishOptions{}))
@@ -52,7 +52,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish plan with errors", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunPlanning
 
 		require.NoError(t, run.Finish(internal.PlanPhase, PhaseFinishOptions{Errored: true}))
@@ -63,7 +63,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish plan with changes", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunPlanning
 
 		run.Plan.ResourceReport = &ResourceReport{Additions: 1}
@@ -76,7 +76,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish plan with changes on run with autoapply enabled", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{
 			AutoApply: internal.Bool(true),
 		})
 		run.Status = internal.RunPlanning
@@ -91,7 +91,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("enqueue apply", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunPlanned
 
 		require.NoError(t, run.EnqueueApply())
@@ -101,7 +101,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("start apply", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunApplyQueued
 
 		require.NoError(t, run.Start(internal.ApplyPhase))
@@ -111,7 +111,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish apply", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunApplying
 
 		require.NoError(t, run.Finish(internal.ApplyPhase, PhaseFinishOptions{}))
@@ -121,7 +121,7 @@ func TestRun_States(t *testing.T) {
 	})
 
 	t.Run("finish apply with errors", func(t *testing.T) {
-		run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+		run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 		run.Status = internal.RunApplying
 
 		require.NoError(t, run.Finish(internal.ApplyPhase, PhaseFinishOptions{Errored: true}))
@@ -132,7 +132,7 @@ func TestRun_States(t *testing.T) {
 }
 
 func TestRun_Cancel_Pending(t *testing.T) {
-	run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+	run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 	enqueue, err := run.Cancel()
 	require.NoError(t, err)
 	assert.False(t, enqueue)
@@ -140,7 +140,7 @@ func TestRun_Cancel_Pending(t *testing.T) {
 }
 
 func TestRun_Cancel_Planning(t *testing.T) {
-	run := NewRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
+	run := newRun(&configversion.ConfigurationVersion{}, &workspace.Workspace{}, RunCreateOptions{})
 	run.Status = internal.RunPlanning
 	enqueue, err := run.Cancel()
 	require.NoError(t, err)

--- a/internal/run/spawner.go
+++ b/internal/run/spawner.go
@@ -105,11 +105,11 @@ func (s *Spawner) handle(ctx context.Context, event cloud.VCSEvent) error {
 	}
 
 	// Determine which workspaces to spawn runs for. If it's a PR then a
-	// (speculative) run is spawned for all workspaces. Otherwise each
-	// workspace's branch setting is checked and if it set then it must match
-	// the event's branch. If it is not set then the event's branch must match
-	// the repo's default branch. If neither of these conditions are true then
-	// the workspace is skipped.
+	// plan-only run is spawned for all workspaces. Otherwise each workspace's
+	// branch setting is checked and if it set then it must match the event's
+	// branch. If it is not set then the event's branch must match the repo's
+	// default branch. If neither of these conditions are true then the
+	// workspace is skipped.
 	filterFunc := func(unfiltered []*workspace.Workspace) (filtered []*workspace.Workspace) {
 		for _, ws := range unfiltered {
 			if ws.Branch != "" && ws.Branch == branch {

--- a/internal/run/starter_test.go
+++ b/internal/run/starter_test.go
@@ -26,7 +26,7 @@ func TestStartRun(t *testing.T) {
 			cv:        cv,
 		})
 
-		got, err := starter.startRun(ctx, ws.ID, planOnly)
+		got, err := starter.startRun(ctx, ws.ID, PlanOnlyOperation)
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 	})
@@ -43,7 +43,7 @@ func TestStartRun(t *testing.T) {
 			provider:  provider,
 		})
 
-		got, err := starter.startRun(ctx, ws.ID, planOnly)
+		got, err := starter.startRun(ctx, ws.ID, PlanOnlyOperation)
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 	})
@@ -60,6 +60,10 @@ type (
 		VCSProviderService
 		ConfigurationVersionService
 		RunService
+	}
+
+	fakeStartRunCloudClient struct {
+		cloud.Client
 	}
 )
 
@@ -84,10 +88,6 @@ func (f *fakeStarterService) GetLatestConfigurationVersion(context.Context, stri
 	return f.cv, nil
 }
 
-func (f *fakeStarterService) CloneConfigurationVersion(context.Context, string, configversion.ConfigurationVersionCreateOptions) (*configversion.ConfigurationVersion, error) {
-	return f.cv, nil
-}
-
 func (f *fakeStarterService) UploadConfig(context.Context, string, []byte) error {
 	return nil
 }
@@ -98,10 +98,6 @@ func (f *fakeStarterService) GetVCSClient(context.Context, string) (cloud.Client
 
 func (f *fakeStarterService) CreateRun(context.Context, string, RunCreateOptions) (*Run, error) {
 	return f.run, nil
-}
-
-type fakeStartRunCloudClient struct {
-	cloud.Client
 }
 
 func (f *fakeStartRunCloudClient) GetRepoTarball(context.Context, cloud.GetRepoTarballOptions) ([]byte, error) {

--- a/internal/run/test_helpers.go
+++ b/internal/run/test_helpers.go
@@ -88,6 +88,6 @@ func (f *fakeWebServices) GetRun(ctx context.Context, runID string) (*Run, error
 	return f.runs[0], nil
 }
 
-func (f *fakeWebServices) startRun(ctx context.Context, workspaceID string, strategy runStrategy) (*Run, error) {
+func (f *fakeWebServices) startRun(context.Context, string, Operation) (*Run, error) {
 	return f.runs[0], nil
 }

--- a/internal/run/web.go
+++ b/internal/run/web.go
@@ -28,7 +28,7 @@ type (
 	}
 
 	runStarter interface {
-		startRun(ctx context.Context, workspaceID string, strategy runStrategy) (*Run, error)
+		startRun(ctx context.Context, workspaceID string, op Operation) (*Run, error)
 	}
 
 	logsdb interface {
@@ -232,15 +232,15 @@ func (h *webHandlers) discard(w http.ResponseWriter, r *http.Request) {
 
 func (h *webHandlers) startRun(w http.ResponseWriter, r *http.Request) {
 	var params struct {
-		WorkspaceID string      `schema:"workspace_id,required"`
-		Strategy    runStrategy `schema:"strategy,required"`
+		WorkspaceID string    `schema:"workspace_id,required"`
+		Operation   Operation `schema:"operation,required"`
 	}
 	if err := decode.All(&params, r); err != nil {
 		h.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
 
-	run, err := h.starter.startRun(r.Context(), params.WorkspaceID, params.Strategy)
+	run, err := h.starter.startRun(r.Context(), params.WorkspaceID, params.Operation)
 	if err != nil {
 		html.FlashError(w, err.Error())
 		http.Redirect(w, r, paths.Workspace(params.WorkspaceID), http.StatusFound)

--- a/internal/run/web_test.go
+++ b/internal/run/web_test.go
@@ -75,7 +75,7 @@ func TestWebHandlers_StartRun(t *testing.T) {
 	run := &Run{ID: "run-1"}
 	h := newTestWebHandlers(t, withRuns(run))
 
-	q := "/?workspace_id=run-123&strategy=plan-only"
+	q := "/?workspace_id=run-123&operation=plan-only"
 	r := httptest.NewRequest("POST", q, nil)
 	w := httptest.NewRecorder()
 	h.startRun(w, r)

--- a/internal/scheduler/queue.go
+++ b/internal/scheduler/queue.go
@@ -58,7 +58,7 @@ func (q *queue) handleEvent(ctx context.Context, event pubsub.Event) error {
 			}
 		}
 	case *run.Run:
-		if payload.Speculative {
+		if payload.PlanOnly {
 			if payload.Status == internal.RunPending {
 				// immediately enqueue onto global queue
 				_, err := q.EnqueuePlan(ctx, payload.ID)

--- a/internal/scheduler/queue_test.go
+++ b/internal/scheduler/queue_test.go
@@ -79,7 +79,7 @@ func TestQueue(t *testing.T) {
 
 	t.Run("speculative run", func(t *testing.T) {
 		ws := &workspace.Workspace{ID: "ws-123"}
-		run := &run.Run{Status: internal.RunPending, WorkspaceID: "ws-123", Speculative: true}
+		run := &run.Run{Status: internal.RunPending, WorkspaceID: "ws-123", PlanOnly: true}
 		app := newFakeQueueApp(ws, run)
 		q := newTestQueue(app, ws)
 

--- a/internal/sql/migrations/20230613192456_add_plan_only_column_to_runs.sql
+++ b/internal/sql/migrations/20230613192456_add_plan_only_column_to_runs.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+ALTER TABLE runs ADD COLUMN plan_only BOOL DEFAULT false;
+
+UPDATE runs r
+SET plan_only = cv.speculative
+FROM configuration_versions cv
+WHERE r.configuration_version_id = cv.configuration_version_id;
+
+ALTER TABLE runs
+    ALTER COLUMN plan_only SET NOT NULL,
+    ALTER COLUMN plan_only DROP DEFAULT;
+
+-- +goose Down
+ALTER TABLE runs DROP COLUMN plan_only;

--- a/internal/sql/pggen/agent_token.sql.go
+++ b/internal/sql/pggen/agent_token.sql.go
@@ -1700,6 +1700,7 @@ type Runs struct {
 	WorkspaceID            pgtype.Text        `json:"workspace_id"`
 	ConfigurationVersionID pgtype.Text        `json:"configuration_version_id"`
 	AutoApply              bool               `json:"auto_apply"`
+	PlanOnly               bool               `json:"plan_only"`
 }
 
 // StateVersionOutputs represents the Postgres composite type "state_version_outputs".
@@ -1932,6 +1933,7 @@ func (tr *typeResolver) newRuns() pgtype.ValueTranscoder {
 		compositeField{"workspace_id", "text", &pgtype.Text{}},
 		compositeField{"configuration_version_id", "text", &pgtype.Text{}},
 		compositeField{"auto_apply", "bool", &pgtype.Bool{}},
+		compositeField{"plan_only", "bool", &pgtype.Bool{}},
 	)
 }
 

--- a/internal/sql/pggen/run.sql.go
+++ b/internal/sql/pggen/run.sql.go
@@ -22,6 +22,7 @@ const insertRunSQL = `INSERT INTO runs (
     replace_addrs,
     target_addrs,
     auto_apply,
+    plan_only,
     configuration_version_id,
     workspace_id
 ) VALUES (
@@ -36,7 +37,8 @@ const insertRunSQL = `INSERT INTO runs (
     $9,
     $10,
     $11,
-    $12
+    $12,
+    $13
 );`
 
 type InsertRunParams struct {
@@ -50,6 +52,7 @@ type InsertRunParams struct {
 	ReplaceAddrs           []string
 	TargetAddrs            []string
 	AutoApply              bool
+	PlanOnly               bool
 	ConfigurationVersionID pgtype.Text
 	WorkspaceID            pgtype.Text
 }
@@ -57,7 +60,7 @@ type InsertRunParams struct {
 // InsertRun implements Querier.InsertRun.
 func (q *DBQuerier) InsertRun(ctx context.Context, params InsertRunParams) (pgconn.CommandTag, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "InsertRun")
-	cmdTag, err := q.conn.Exec(ctx, insertRunSQL, params.ID, params.CreatedAt, params.IsDestroy, params.PositionInQueue, params.Refresh, params.RefreshOnly, params.Status, params.ReplaceAddrs, params.TargetAddrs, params.AutoApply, params.ConfigurationVersionID, params.WorkspaceID)
+	cmdTag, err := q.conn.Exec(ctx, insertRunSQL, params.ID, params.CreatedAt, params.IsDestroy, params.PositionInQueue, params.Refresh, params.RefreshOnly, params.Status, params.ReplaceAddrs, params.TargetAddrs, params.AutoApply, params.PlanOnly, params.ConfigurationVersionID, params.WorkspaceID)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query InsertRun: %w", err)
 	}
@@ -66,7 +69,7 @@ func (q *DBQuerier) InsertRun(ctx context.Context, params InsertRunParams) (pgco
 
 // InsertRunBatch implements Querier.InsertRunBatch.
 func (q *DBQuerier) InsertRunBatch(batch genericBatch, params InsertRunParams) {
-	batch.Queue(insertRunSQL, params.ID, params.CreatedAt, params.IsDestroy, params.PositionInQueue, params.Refresh, params.RefreshOnly, params.Status, params.ReplaceAddrs, params.TargetAddrs, params.AutoApply, params.ConfigurationVersionID, params.WorkspaceID)
+	batch.Queue(insertRunSQL, params.ID, params.CreatedAt, params.IsDestroy, params.PositionInQueue, params.Refresh, params.RefreshOnly, params.Status, params.ReplaceAddrs, params.TargetAddrs, params.AutoApply, params.PlanOnly, params.ConfigurationVersionID, params.WorkspaceID)
 }
 
 // InsertRunScan implements Querier.InsertRunScan.
@@ -136,7 +139,7 @@ const findRunsSQL = `SELECT
     applies.report AS applied_changes,
     runs.configuration_version_id,
     runs.workspace_id,
-    configuration_versions.speculative,
+    runs.plan_only,
     workspaces.execution_mode AS execution_mode,
     CASE WHEN workspaces.latest_run_id = runs.run_id THEN true
          ELSE false
@@ -173,7 +176,7 @@ WHERE
 AND workspaces.workspace_id                  LIKE ANY($2)
 AND workspaces.name                          LIKE ANY($3)
 AND runs.status                              LIKE ANY($4)
-AND configuration_versions.speculative::text LIKE ANY($5)
+AND runs.plan_only::text LIKE ANY($5)
 ORDER BY runs.created_at DESC
 LIMIT $6 OFFSET $7
 ;`
@@ -206,7 +209,7 @@ type FindRunsRow struct {
 	AppliedChanges         *Report                 `json:"applied_changes"`
 	ConfigurationVersionID pgtype.Text             `json:"configuration_version_id"`
 	WorkspaceID            pgtype.Text             `json:"workspace_id"`
-	Speculative            bool                    `json:"speculative"`
+	PlanOnly               bool                    `json:"plan_only"`
 	ExecutionMode          pgtype.Text             `json:"execution_mode"`
 	Latest                 bool                    `json:"latest"`
 	OrganizationName       pgtype.Text             `json:"organization_name"`
@@ -233,7 +236,7 @@ func (q *DBQuerier) FindRuns(ctx context.Context, params FindRunsParams) ([]Find
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	for rows.Next() {
 		var item FindRunsRow
-		if err := rows.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+		if err := rows.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 			return nil, fmt.Errorf("scan FindRuns row: %w", err)
 		}
 		if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {
@@ -283,7 +286,7 @@ func (q *DBQuerier) FindRunsScan(results pgx.BatchResults) ([]FindRunsRow, error
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	for rows.Next() {
 		var item FindRunsRow
-		if err := rows.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+		if err := rows.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 			return nil, fmt.Errorf("scan FindRunsBatch row: %w", err)
 		}
 		if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {
@@ -315,13 +318,12 @@ func (q *DBQuerier) FindRunsScan(results pgx.BatchResults) ([]FindRunsRow, error
 const countRunsSQL = `SELECT count(*)
 FROM runs
 JOIN workspaces             USING(workspace_id)
-JOIN configuration_versions USING(configuration_version_id)
 WHERE
     workspaces.organization_name             LIKE ANY($1)
 AND workspaces.workspace_id                  LIKE ANY($2)
 AND workspaces.name                          LIKE ANY($3)
 AND runs.status                              LIKE ANY($4)
-AND configuration_versions.speculative::text LIKE ANY($5)
+AND runs.plan_only::text LIKE ANY($5)
 ;`
 
 type CountRunsParams struct {
@@ -376,7 +378,7 @@ const findRunByIDSQL = `SELECT
     applies.report AS applied_changes,
     runs.configuration_version_id,
     runs.workspace_id,
-    configuration_versions.speculative,
+    runs.plan_only,
     workspaces.execution_mode AS execution_mode,
     CASE WHEN workspaces.latest_run_id = runs.run_id THEN true
          ELSE false
@@ -429,7 +431,7 @@ type FindRunByIDRow struct {
 	AppliedChanges         *Report                 `json:"applied_changes"`
 	ConfigurationVersionID pgtype.Text             `json:"configuration_version_id"`
 	WorkspaceID            pgtype.Text             `json:"workspace_id"`
-	Speculative            bool                    `json:"speculative"`
+	PlanOnly               bool                    `json:"plan_only"`
 	ExecutionMode          pgtype.Text             `json:"execution_mode"`
 	Latest                 bool                    `json:"latest"`
 	OrganizationName       pgtype.Text             `json:"organization_name"`
@@ -450,7 +452,7 @@ func (q *DBQuerier) FindRunByID(ctx context.Context, runID pgtype.Text) (FindRun
 	runStatusTimestampsArray := q.types.newRunStatusTimestampsArray()
 	planStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
-	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 		return item, fmt.Errorf("query FindRunByID: %w", err)
 	}
 	if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {
@@ -489,7 +491,7 @@ func (q *DBQuerier) FindRunByIDScan(results pgx.BatchResults) (FindRunByIDRow, e
 	runStatusTimestampsArray := q.types.newRunStatusTimestampsArray()
 	planStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
-	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 		return item, fmt.Errorf("scan FindRunByIDBatch row: %w", err)
 	}
 	if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {
@@ -531,7 +533,7 @@ const findRunByIDForUpdateSQL = `SELECT
     applies.report AS applied_changes,
     runs.configuration_version_id,
     runs.workspace_id,
-    configuration_versions.speculative,
+    runs.plan_only,
     workspaces.execution_mode AS execution_mode,
     CASE WHEN workspaces.latest_run_id = runs.run_id THEN true
          ELSE false
@@ -585,7 +587,7 @@ type FindRunByIDForUpdateRow struct {
 	AppliedChanges         *Report                 `json:"applied_changes"`
 	ConfigurationVersionID pgtype.Text             `json:"configuration_version_id"`
 	WorkspaceID            pgtype.Text             `json:"workspace_id"`
-	Speculative            bool                    `json:"speculative"`
+	PlanOnly               bool                    `json:"plan_only"`
 	ExecutionMode          pgtype.Text             `json:"execution_mode"`
 	Latest                 bool                    `json:"latest"`
 	OrganizationName       pgtype.Text             `json:"organization_name"`
@@ -606,7 +608,7 @@ func (q *DBQuerier) FindRunByIDForUpdate(ctx context.Context, runID pgtype.Text)
 	runStatusTimestampsArray := q.types.newRunStatusTimestampsArray()
 	planStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
-	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 		return item, fmt.Errorf("query FindRunByIDForUpdate: %w", err)
 	}
 	if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {
@@ -645,7 +647,7 @@ func (q *DBQuerier) FindRunByIDForUpdateScan(results pgx.BatchResults) (FindRunB
 	runStatusTimestampsArray := q.types.newRunStatusTimestampsArray()
 	planStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
 	applyStatusTimestampsArray := q.types.newPhaseStatusTimestampsArray()
-	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.Speculative, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
+	if err := row.Scan(&item.RunID, &item.CreatedAt, &item.ForceCancelAvailableAt, &item.IsDestroy, &item.PositionInQueue, &item.Refresh, &item.RefreshOnly, &item.Status, &item.PlanStatus, &item.ApplyStatus, &item.ReplaceAddrs, &item.TargetAddrs, &item.AutoApply, plannedChangesRow, appliedChangesRow, &item.ConfigurationVersionID, &item.WorkspaceID, &item.PlanOnly, &item.ExecutionMode, &item.Latest, &item.OrganizationName, ingressAttributesRow, runStatusTimestampsArray, planStatusTimestampsArray, applyStatusTimestampsArray); err != nil {
 		return item, fmt.Errorf("scan FindRunByIDForUpdateBatch row: %w", err)
 	}
 	if err := plannedChangesRow.AssignTo(&item.PlannedChanges); err != nil {


### PR DESCRIPTION
Adds support for the specifying the `plan-only` attribute when creating a run via the API:

https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run

This overrides the `speculative` attribute when specified on the configuration version for the run.

Note: throughout TFC documentation, both "speculative" and "plan-only" are used to refer to the same thing: a run that only performs a plan and does not follow through to an apply. I think Hashicorp are increasingly using the latter term, "plan-only", because it is more descriptive. I've followed suit in this PR and updated the OTF codebase to use variants of the latter term and minimise references to "speculative" runs.