### PR TITLE
fix: real-time run listing updates

### DIFF
--- a/internal/http/html/static/templates/content/run_listing.tmpl
+++ b/internal/http/html/static/templates/content/run_listing.tmpl
@@ -1,1 +1,1 @@
-{{ template "run_listing" . }}
+{{ template "run-listing" . }}

--- a/internal/integration/run_list_ui_test.go
+++ b/internal/integration/run_list_ui_test.go
@@ -19,10 +19,7 @@ func TestIntegration_RunListUI(t *testing.T) {
 	ws := daemon.createWorkspace(t, ctx, nil)
 	tfConfig := newRootModule(t, daemon.Hostname(), ws.Organization, ws.Name)
 
-	var (
-		runListingBefore []*cdp.Node
-		runListingAfter  []*cdp.Node
-	)
+	var runListingAfter []*cdp.Node
 	browser := createBrowserCtx(t)
 	err := chromedp.Run(browser, chromedp.Tasks{
 		newSession(t, ctx, daemon.Hostname(), user.Username, daemon.Secret),
@@ -46,7 +43,5 @@ func TestIntegration_RunListUI(t *testing.T) {
 		chromedp.WaitVisible(`//*[@class='item']//*[@class='status status-planned_and_finished']`, chromedp.BySearch),
 	})
 	require.NoError(t, err)
-
-	assert.Equal(t, 0, len(runListingBefore))
 	assert.Equal(t, 1, len(runListingAfter))
 }

--- a/internal/integration/run_list_ui_test.go
+++ b/internal/integration/run_list_ui_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/chromedp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_RunListUI demonstrates listing runs via the UI.
+func TestIntegration_RunListUI(t *testing.T) {
+	t.Parallel()
+
+	daemon := setup(t, nil)
+	user, ctx := daemon.createUserCtx(t, ctx)
+	ws := daemon.createWorkspace(t, ctx, nil)
+	tfConfig := newRootModule(t, daemon.Hostname(), ws.Organization, ws.Name)
+
+	var (
+		runListingBefore []*cdp.Node
+		runListingAfter  []*cdp.Node
+	)
+	browser := createBrowserCtx(t)
+	err := chromedp.Run(browser, chromedp.Tasks{
+		newSession(t, ctx, daemon.Hostname(), user.Username, daemon.Secret),
+		// navigate to workspace page
+		chromedp.Navigate(workspaceURL(daemon.Hostname(), ws.Organization, ws.Name)),
+		chromedp.WaitReady(`body`),
+		// navigate to runs page
+		chromedp.Click(`//a[text()='runs']`, chromedp.NodeVisible),
+		chromedp.WaitReady(`body`),
+		// should be no items listed
+		matchText(t, `//div[@id='content-list']`, `No items currently exist.`),
+		chromedp.ActionFunc(func(context.Context) error {
+			// meanwhile, execute a terraform cli init and plan
+			daemon.tfcli(t, ctx, "init", tfConfig)
+			daemon.tfcli(t, ctx, "plan", tfConfig)
+			return nil
+		}),
+		// should be one run listed
+		chromedp.Nodes(`//div[@id='content-list']//*[@class='item']`, &runListingAfter, chromedp.BySearch),
+		// and its status should 'planned and finished'
+		chromedp.WaitVisible(`//*[@class='item']//*[@class='status status-planned_and_finished']`, chromedp.BySearch),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, len(runListingBefore))
+	assert.Equal(t, 1, len(runListingAfter))
+}

--- a/internal/integration/run_list_ui_test.go
+++ b/internal/integration/run_list_ui_test.go
@@ -29,7 +29,7 @@ func TestIntegration_RunListUI(t *testing.T) {
 		// navigate to runs page
 		chromedp.Click(`//a[text()='runs']`, chromedp.NodeVisible),
 		chromedp.WaitReady(`body`),
-		// should be no items listed
+		// should be no runs listed
 		matchText(t, `//div[@id='content-list']`, `No items currently exist.`),
 		chromedp.ActionFunc(func(context.Context) error {
 			// meanwhile, execute a terraform cli init and plan
@@ -39,7 +39,7 @@ func TestIntegration_RunListUI(t *testing.T) {
 		}),
 		// should be one run listed
 		chromedp.Nodes(`//div[@id='content-list']//*[@class='item']`, &runListingAfter, chromedp.BySearch),
-		// and its status should 'planned and finished'
+		// and its status should be 'planned and finished'
 		chromedp.WaitVisible(`//*[@class='item']//*[@class='status status-planned_and_finished']`, chromedp.BySearch),
 	})
 	require.NoError(t, err)

--- a/internal/integration/workspace_ui_test.go
+++ b/internal/integration/workspace_ui_test.go
@@ -29,10 +29,12 @@ func TestIntegration_WorkspaceUI(t *testing.T) {
 		createWorkspace(t, daemon.Hostname(), org.Name, "workspace-12"),
 		createWorkspace(t, daemon.Hostname(), org.Name, "workspace-2"),
 		chromedp.Navigate(workspacesURL(daemon.Hostname(), org.Name)),
+		chromedp.WaitReady(`body`),
 		// search for 'workspace-1' which should produce two results
 		chromedp.Focus(`input[type="search"]`, chromedp.NodeVisible),
 		input.InsertText("workspace-1"),
 		chromedp.Submit(`input[type="search"]`),
+		chromedp.WaitReady(`body`),
 		chromedp.Nodes(`//*[@class="item"]`, &workspaceItems, chromedp.BySearch),
 		chromedp.ActionFunc(func(c context.Context) error {
 			assert.Equal(t, 2, len(workspaceItems))
@@ -42,7 +44,7 @@ func TestIntegration_WorkspaceUI(t *testing.T) {
 		chromedp.WaitNotPresent(`//*[@id="item-workspace-workspace-2"]`, chromedp.BySearch),
 		// clear search term
 		chromedp.SendKeys(`input[type="search"]`, strings.Repeat(kb.Delete, len("workspace-1")), chromedp.BySearch),
-		// now workspace-2 should be visible.
+		// now workspace-2 should be visible (updated via ajax)
 		chromedp.WaitVisible(`//*[@id="item-workspace-workspace-2"]`, chromedp.BySearch),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Real-time updates to the run listing on the UI were broken by an incorrect template name.

* Fixes this
* Adds browser-based test