### PR TITLE
feat!: add team membership tfe api endpoints

### DIFF
--- a/hack/go-tfe-tests-upstream.bash
+++ b/hack/go-tfe-tests-upstream.bash
@@ -26,6 +26,9 @@ tests+=('TestNotificationConfigurationDelete')
 tests+=('TestNotificationConfigurationUpdate/with_options')
 tests+=('TestNotificationConfigurationUpdate/without_options')
 tests+=('TestNotificationConfigurationUpdate/^when')
+tests+=('TestTeamMembersAddByUsername')
+tests+=('TestTeamMembersRemoveByUsernames')
+tests+=('TestTeamMembersList')
 all=$(join_by '|' "${tests[@]}")
 
 ./hack/go-tfe-tests.bash $all

--- a/hack/go-tfe-tests.bash
+++ b/hack/go-tfe-tests.bash
@@ -2,7 +2,7 @@
 
 # Run go-tfe tests against otfd. It's recommended you first start otfd and
 # postgres using docker compose before running this script. This script
-# expects to find otfd running on port 8833 which is the port the docker
+# expects to find otfd running on port 8080 which is the port the docker
 # compose otfd listens on.
 #
 # Either specify tests as arguments or a default subset of tests will be run.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -47,6 +47,7 @@ type (
 		workspace.WorkspaceService
 		configversion.ConfigurationVersionService
 		auth.AuthService
+		auth.TeamService
 		tokens.TokensService
 		variable.VariableService
 		notifications.NotificationService
@@ -75,6 +76,7 @@ func New(opts Options) *api {
 			WorkspaceService:    opts.WorkspaceService,
 			RunService:          opts.RunService,
 			StateService:        opts.StateService,
+			TeamService:         opts.TeamService,
 			runLogsURLGenerator: &runLogsURLGenerator{opts.Signer},
 		},
 		maxConfigSize: opts.MaxConfigSize,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -90,6 +90,7 @@ func (a *api) AddHandlers(r *mux.Router) {
 	a.addConfigHandlers(r)
 	a.addUserHandlers(r)
 	a.addTeamHandlers(r)
+	a.addTeamMembershipHandlers(r)
 	a.addVariableHandlers(r)
 	a.addTokenHandlers(r)
 	a.addNotificationHandlers(r)

--- a/internal/api/marshaler.go
+++ b/internal/api/marshaler.go
@@ -33,6 +33,7 @@ type (
 		organization.OrganizationService
 		state.StateService
 		workspace.WorkspaceService
+		auth.TeamService
 
 		*runLogsURLGenerator
 	}
@@ -86,7 +87,7 @@ func (m *jsonapiMarshaler) writeResponse(w http.ResponseWriter, r *http.Request,
 	case *auth.User:
 		payload = m.toUser(v)
 	case *auth.Team:
-		payload = m.toTeam(v)
+		payload, marshalOpts, err = m.toTeam(v, r)
 	case *workspace.TagList:
 		payload, marshalOpts = m.toTags(v)
 	default:

--- a/internal/api/team_marshaler.go
+++ b/internal/api/team_marshaler.go
@@ -1,13 +1,37 @@
 package api
 
 import (
+	"net/http"
+	"strings"
+
+	"github.com/DataDog/jsonapi"
 	"github.com/leg100/otf/internal/api/types"
 	"github.com/leg100/otf/internal/auth"
 )
 
-func (m *jsonapiMarshaler) toTeam(from *auth.Team) *types.Team {
+func (m *jsonapiMarshaler) toTeam(from *auth.Team, r *http.Request) (*types.Team, []jsonapi.MarshalOption, error) {
+	// Support including related resources:
+	//
+	// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams#available-related-resources
+	var opts []jsonapi.MarshalOption
+	if includes := r.URL.Query().Get("include"); includes != "" {
+		for _, inc := range strings.Split(includes, ",") {
+			switch inc {
+			case "users":
+				var include []any
+				users, err := m.ListTeamMembers(r.Context(), from.ID)
+				if err != nil {
+					return nil, nil, err
+				}
+				for _, user := range users {
+					include = append(include, m.toUser(user))
+				}
+				opts = append(opts, jsonapi.MarshalInclude(include...))
+			}
+		}
+	}
 	return &types.Team{
 		ID:   from.ID,
 		Name: from.Name,
-	}
+	}, opts, nil
 }

--- a/internal/api/team_marshaler.go
+++ b/internal/api/team_marshaler.go
@@ -10,6 +10,11 @@ import (
 )
 
 func (m *jsonapiMarshaler) toTeam(from *auth.Team, r *http.Request) (*types.Team, []jsonapi.MarshalOption, error) {
+	to := &types.Team{
+		ID:   from.ID,
+		Name: from.Name,
+	}
+
 	// Support including related resources:
 	//
 	// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams#available-related-resources
@@ -25,13 +30,11 @@ func (m *jsonapiMarshaler) toTeam(from *auth.Team, r *http.Request) (*types.Team
 				}
 				for _, user := range users {
 					include = append(include, m.toUser(user))
+					to.Users = append(to.Users, m.toUser(user))
 				}
 				opts = append(opts, jsonapi.MarshalInclude(include...))
 			}
 		}
 	}
-	return &types.Team{
-		ID:   from.ID,
-		Name: from.Name,
-	}, opts, nil
+	return to, opts, nil
 }

--- a/internal/api/team_membership.go
+++ b/internal/api/team_membership.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/leg100/otf/internal/auth"
+	otfhttp "github.com/leg100/otf/internal/http"
+	"github.com/leg100/otf/internal/http/decode"
+)
+
+const (
+	addTeamMembersAction teamMembersAction = iota
+	removeTeamMembersAction
+)
+
+type teamMembersAction int
+
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-members
+func (a *api) addTeamMembershipHandlers(r *mux.Router) {
+	r = otfhttp.APIRouter(r)
+
+	r.HandleFunc("/teams/{team_id}/relationships/users", a.addTeamMembers).Methods("POST")
+	r.HandleFunc("/teams/{team_id}/relationships/users", a.removeTeamMembers).Methods("DELETE")
+}
+
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-members#add-a-user-to-team-with-user-id
+func (a *api) addTeamMembers(w http.ResponseWriter, r *http.Request) {
+	if err := a.modifyTeamMembers(r, addTeamMembersAction); err != nil {
+		Error(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (a *api) removeTeamMembers(w http.ResponseWriter, r *http.Request) {
+	if err := a.modifyTeamMembers(r, removeTeamMembersAction); err != nil {
+		Error(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *api) modifyTeamMembers(r *http.Request, action teamMembersAction) error {
+	teamID, err := decode.Param("team_id", r)
+	if err != nil {
+		return err
+	}
+
+	type teamMember struct {
+		Username string `jsonapi:"primary,users"`
+	}
+	var users []teamMember
+	if err := unmarshal(r.Body, &users); err != nil {
+		return err
+	}
+
+	// convert users into a simple slice of usernames
+	var usernames []string
+	for _, u := range users {
+		usernames = append(usernames, u.Username)
+	}
+
+	opts := auth.TeamMembershipOptions{
+		TeamID:    teamID,
+		Usernames: usernames,
+	}
+	switch action {
+	case addTeamMembersAction:
+		return a.AddTeamMembership(r.Context(), opts)
+	case removeTeamMembersAction:
+		return a.RemoveTeamMembership(r.Context(), opts)
+	default:
+		return fmt.Errorf("unknown team membership action: %v", action)
+	}
+}

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -9,9 +9,14 @@ import (
 	"github.com/leg100/otf/internal/api/types"
 )
 
-type Client struct {
-	internal.JSONAPIClient
-}
+type (
+	Client struct {
+		internal.JSONAPIClient
+	}
+	teamMember struct {
+		Username string `jsonapi:"primary,users"`
+	}
+)
 
 // CreateUser creates a user via HTTP/JSONAPI. Options are ignored.
 func (c *Client) CreateUser(ctx context.Context, username string, _ ...NewUserOption) (*User, error) {
@@ -42,10 +47,15 @@ func (c *Client) DeleteUser(ctx context.Context, username string) error {
 	return nil
 }
 
-// AddTeamMembership adds a user to a team via HTTP.
+// AddTeamMembership adds users to a team via HTTP.
 func (c *Client) AddTeamMembership(ctx context.Context, opts TeamMembershipOptions) error {
-	u := fmt.Sprintf("teams/%s/memberships/%s", url.QueryEscape(opts.TeamID), url.QueryEscape(opts.Username))
-	req, err := c.NewRequest("POST", u, nil)
+	var members []*teamMember
+	for _, name := range opts.Usernames {
+		members = append(members, &teamMember{Username: name})
+	}
+
+	u := fmt.Sprintf("teams/%s/relationships/users", url.QueryEscape(opts.TeamID))
+	req, err := c.NewRequest("POST", u, members)
 	if err != nil {
 		return err
 	}
@@ -55,10 +65,15 @@ func (c *Client) AddTeamMembership(ctx context.Context, opts TeamMembershipOptio
 	return nil
 }
 
-// RemoveTeamMembership removes a user from a team via HTTP.
+// RemoveTeamMembership removes users from a team via HTTP.
 func (c *Client) RemoveTeamMembership(ctx context.Context, opts TeamMembershipOptions) error {
-	u := fmt.Sprintf("teams/%s/memberships/%s", url.QueryEscape(opts.TeamID), url.QueryEscape(opts.Username))
-	req, err := c.NewRequest("DELETE", u, nil)
+	var members []*teamMember
+	for _, name := range opts.Usernames {
+		members = append(members, &teamMember{Username: name})
+	}
+
+	u := fmt.Sprintf("teams/%s/relationships/users", url.QueryEscape(opts.TeamID))
+	req, err := c.NewRequest("DELETE", u, members)
 	if err != nil {
 		return err
 	}

--- a/internal/auth/team_web.go
+++ b/internal/auth/team_web.go
@@ -182,13 +182,20 @@ func (h *webHandlers) deleteTeam(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *webHandlers) addTeamMember(w http.ResponseWriter, r *http.Request) {
-	var params TeamMembershipOptions
+	var params struct {
+		TeamID   string `schema:"team_id,required"`
+		Username string `schema:"username,required"`
+	}
 	if err := decode.All(&params, r); err != nil {
 		h.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
 
-	if err := h.svc.AddTeamMembership(r.Context(), params); err != nil {
+	err := h.svc.AddTeamMembership(r.Context(), TeamMembershipOptions{
+		TeamID:    params.TeamID,
+		Usernames: []string{params.Username},
+	})
+	if err != nil {
 		h.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -198,13 +205,20 @@ func (h *webHandlers) addTeamMember(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *webHandlers) removeTeamMember(w http.ResponseWriter, r *http.Request) {
-	var params TeamMembershipOptions
+	var params struct {
+		TeamID   string `schema:"team_id,required"`
+		Username string `schema:"username,required"`
+	}
 	if err := decode.All(&params, r); err != nil {
 		h.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
 
-	if err := h.svc.RemoveTeamMembership(r.Context(), params); err != nil {
+	err := h.svc.RemoveTeamMembership(r.Context(), TeamMembershipOptions{
+		TeamID:    params.TeamID,
+		Usernames: []string{params.Username},
+	})
+	if err != nil {
 		h.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/user_db.go
+++ b/internal/auth/user_db.go
@@ -23,7 +23,7 @@ func (db *pgdb) CreateUser(ctx context.Context, user *User) error {
 			return sql.Error(err)
 		}
 		for _, team := range user.Teams {
-			_, err = tx.InsertTeamMembership(ctx, sql.String(user.Username), sql.String(team.ID))
+			_, err = tx.InsertTeamMembership(ctx, []string{user.Username}, sql.String(team.ID))
 			if err != nil {
 				return sql.Error(err)
 			}
@@ -94,16 +94,16 @@ func (db *pgdb) getUser(ctx context.Context, spec UserSpec) (*User, error) {
 	}
 }
 
-func (db *pgdb) addTeamMembership(ctx context.Context, username, teamID string) error {
-	_, err := db.InsertTeamMembership(ctx, sql.String(username), sql.String(teamID))
+func (db *pgdb) addTeamMembership(ctx context.Context, teamID string, usernames ...string) error {
+	_, err := db.InsertTeamMembership(ctx, usernames, sql.String(teamID))
 	if err != nil {
 		return sql.Error(err)
 	}
 	return nil
 }
 
-func (db *pgdb) removeTeamMembership(ctx context.Context, username, teamID string) error {
-	_, err := db.DeleteTeamMembership(ctx, sql.String(username), sql.String(teamID))
+func (db *pgdb) removeTeamMembership(ctx context.Context, teamID string, usernames ...string) error {
+	_, err := db.DeleteTeamMembership(ctx, usernames, sql.String(teamID))
 	if err != nil {
 		return sql.Error(err)
 	}

--- a/internal/auth/user_service.go
+++ b/internal/auth/user_service.go
@@ -22,9 +22,9 @@ type (
 		SetSiteAdmins(ctx context.Context, usernames ...string) error
 	}
 	TeamMembershipOptions struct {
-		Username string `schema:"username,required"`
-		TeamID   string `schema:"team_id,required"`
-		Tx       internal.DB
+		Usernames []string
+		TeamID    string
+		Tx        internal.DB
 	}
 )
 
@@ -119,11 +119,11 @@ func (a *service) AddTeamMembership(ctx context.Context, opts TeamMembershipOpti
 		return err
 	}
 
-	if err := db.addTeamMembership(ctx, opts.Username, opts.TeamID); err != nil {
-		a.Error(err, "adding team membership", "user", opts.Username, "team", opts.TeamID, "subject", subject)
+	if err := db.addTeamMembership(ctx, opts.TeamID, opts.Usernames...); err != nil {
+		a.Error(err, "adding team membership", "user", opts.Usernames, "team", opts.TeamID, "subject", subject)
 		return err
 	}
-	a.V(0).Info("added team membership", "user", opts.Username, "team", opts.TeamID, "subject", subject)
+	a.V(0).Info("added team membership", "users", opts.Usernames, "team", opts.TeamID, "subject", subject)
 
 	return nil
 }
@@ -157,11 +157,11 @@ func (a *service) RemoveTeamMembership(ctx context.Context, opts TeamMembershipO
 		}
 	}
 
-	if err := db.removeTeamMembership(ctx, opts.Username, opts.TeamID); err != nil {
-		a.Error(err, "removing team membership", "user", opts.Username, "team", opts.TeamID, "subject", subject)
+	if err := db.removeTeamMembership(ctx, opts.TeamID, opts.Usernames...); err != nil {
+		a.Error(err, "removing team membership", "users", opts.Usernames, "team", opts.TeamID, "subject", subject)
 		return err
 	}
-	a.V(0).Info("removed team membership", "user", opts.Username, "team", opts.TeamID, "subject", subject)
+	a.V(0).Info("removed team membership", "users", opts.Usernames, "team", opts.TeamID, "subject", subject)
 
 	return nil
 }

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -84,9 +84,9 @@ func (a *CLI) addTeamMembershipCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:           "add-user [username]",
-		Short:         "Add user to team",
-		Args:          cobra.ExactArgs(1),
+		Use:           "add-users [username|...]",
+		Short:         "Add users to team",
+		Args:          cobra.MinimumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,13 +95,13 @@ func (a *CLI) addTeamMembershipCommand() *cobra.Command {
 				return err
 			}
 			err = a.AddTeamMembership(cmd.Context(), auth.TeamMembershipOptions{
-				Username: args[0],
-				TeamID:   team.ID,
+				Usernames: args,
+				TeamID:    team.ID,
 			})
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Successfully added %s to %s\n", args[0], name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully added %s to %s\n", args, name)
 			return nil
 		},
 	}
@@ -121,9 +121,9 @@ func (a *CLI) deleteTeamMembershipCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:           "del-user [username]",
-		Short:         "Delete user from team",
-		Args:          cobra.ExactArgs(1),
+		Use:           "del-users [username|...]",
+		Short:         "Delete users from team",
+		Args:          cobra.MinimumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -132,13 +132,13 @@ func (a *CLI) deleteTeamMembershipCommand() *cobra.Command {
 				return err
 			}
 			err = a.RemoveTeamMembership(cmd.Context(), auth.TeamMembershipOptions{
-				Username: args[0],
-				TeamID:   team.ID,
+				Usernames: args,
+				TeamID:    team.ID,
 			})
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed %s from %s\n", args[0], name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed %s from %s\n", args, name)
 			return nil
 		},
 	}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -37,22 +37,22 @@ func TestTeam_AddMembership(t *testing.T) {
 	team := &auth.Team{Name: "owners", Organization: "acme-corp"}
 	cmd := fakeApp(withTeam(team)).addTeamMembershipCommand()
 
-	cmd.SetArgs([]string{"bobby", "--organization", "acme-corp", "--team", "owners"})
+	cmd.SetArgs([]string{"bobby", "sally", "--organization", "acme-corp", "--team", "owners"})
 	got := bytes.Buffer{}
 	cmd.SetOut(&got)
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, "Successfully added bobby to owners\n", got.String())
+	assert.Equal(t, "Successfully added [bobby sally] to owners\n", got.String())
 }
 
 func TestTeam_RemoveMembership(t *testing.T) {
 	team := &auth.Team{Name: "owners", Organization: "acme-corp"}
 	cmd := fakeApp(withTeam(team)).deleteTeamMembershipCommand()
 
-	cmd.SetArgs([]string{"bobby", "--organization", "acme-corp", "--team", "owners"})
+	cmd.SetArgs([]string{"bobby", "sally", "--organization", "acme-corp", "--team", "owners"})
 	got := bytes.Buffer{}
 	cmd.SetOut(&got)
 	require.NoError(t, cmd.Execute())
 
-	assert.Equal(t, "Successfully removed bobby from owners\n", got.String())
+	assert.Equal(t, "Successfully removed [bobby sally] from owners\n", got.String())
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -290,6 +290,7 @@ func New(ctx context.Context, logger logr.Logger, cfg Config) (*Daemon, error) {
 		ConfigurationVersionService: configService,
 		AuthService:                 authService,
 		TokensService:               tokensService,
+		TeamService:                 authService,
 		VariableService:             variableService,
 		NotificationService:         notificationService,
 		Signer:                      signer,

--- a/internal/integration/organization_min_permissions_test.go
+++ b/internal/integration/organization_min_permissions_test.go
@@ -22,8 +22,8 @@ func TestIntegration_MinimumPermissions(t *testing.T) {
 	guest := svc.createUser(t)
 	guests := svc.createTeam(t, ctx, org)
 	err := svc.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-		TeamID:   guests.ID,
-		Username: guest.Username,
+		TeamID:    guests.ID,
+		Usernames: []string{guest.Username},
 	})
 	require.NoError(t, err)
 	// Refresh guest user context to include new team membership

--- a/internal/integration/plan_permission_e2e_test.go
+++ b/internal/integration/plan_permission_e2e_test.go
@@ -21,8 +21,8 @@ func TestIntegration_PlanPermission(t *testing.T) {
 	engineer, engineerCtx := svc.createUserCtx(t)
 	team := svc.createTeam(t, ctx, org)
 	err := svc.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-		TeamID:   team.ID,
-		Username: engineer.Username,
+		TeamID:    team.ID,
+		Usernames: []string{engineer.Username},
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/team_cli_test.go
+++ b/internal/integration/team_cli_test.go
@@ -20,23 +20,25 @@ func TestTeamCLI(t *testing.T) {
 	out = daemon.otfcli(t, ctx, "teams", "new", "devs", "--organization", "acme-corp")
 	require.Equal(t, "Successfully created team devs\n", out)
 
-	// create user via cli
+	// create users via cli
 	out = daemon.otfcli(t, adminCtx, "users", "new", "bobby")
 	require.Equal(t, "Successfully created user bobby\n", out)
+	out = daemon.otfcli(t, adminCtx, "users", "new", "sally")
+	require.Equal(t, "Successfully created user sally\n", out)
 
-	// add user to developers
-	out = daemon.otfcli(t, ctx, "teams", "add-user", "bobby",
+	// add users to developers
+	out = daemon.otfcli(t, ctx, "teams", "add-users", "bobby", "sally",
 		"--organization", "acme-corp",
 		"--team", "devs",
 	)
-	require.Equal(t, "Successfully added bobby to devs\n", out)
+	require.Equal(t, "Successfully added [bobby sally] to devs\n", out)
 
-	// remove user from team
-	out = daemon.otfcli(t, ctx, "teams", "del-user", "bobby",
+	// remove users from team
+	out = daemon.otfcli(t, ctx, "teams", "del-users", "bobby", "sally",
 		"--organization", "acme-corp",
 		"--team", "devs",
 	)
-	require.Equal(t, "Successfully removed bobby from devs\n", out)
+	require.Equal(t, "Successfully removed [bobby sally] from devs\n", out)
 
 	// delete team
 	out = daemon.otfcli(t, ctx, "teams", "delete", "devs",

--- a/internal/integration/user_test.go
+++ b/internal/integration/user_test.go
@@ -164,8 +164,8 @@ func TestUser(t *testing.T) {
 		user := svc.createUser(t)
 
 		err := svc.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-			Username: user.Username,
-			TeamID:   team.ID,
+			Usernames: []string{user.Username},
+			TeamID:    team.ID,
 		})
 		require.NoError(t, err)
 
@@ -182,8 +182,8 @@ func TestUser(t *testing.T) {
 		user := svc.createUser(t, auth.WithTeams(team))
 
 		err := svc.RemoveTeamMembership(ctx, auth.TeamMembershipOptions{
-			Username: user.Username,
-			TeamID:   team.ID,
+			Usernames: []string{user.Username},
+			TeamID:    team.ID,
 		})
 		require.NoError(t, err)
 
@@ -202,8 +202,8 @@ func TestUser(t *testing.T) {
 		require.NoError(t, err)
 
 		err = svc.RemoveTeamMembership(ctx, auth.TeamMembershipOptions{
-			Username: owner.Username,
-			TeamID:   owners.ID,
+			Usernames: []string{owner.Username},
+			TeamID:    owners.ID,
 		})
 		assert.Equal(t, auth.ErrCannotDeleteOnlyOwner, err)
 	})

--- a/internal/integration/web_test.go
+++ b/internal/integration/web_test.go
@@ -22,8 +22,8 @@ func TestWeb(t *testing.T) {
 	})
 	require.NoError(t, err)
 	err = daemon.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-		TeamID:   team.ID,
-		Username: user.Username,
+		TeamID:    team.ID,
+		Usernames: []string{user.Username},
 	})
 	require.NoError(t, err)
 

--- a/internal/integration/write_permission_e2e_test.go
+++ b/internal/integration/write_permission_e2e_test.go
@@ -20,8 +20,8 @@ func TestWritePermissionE2E(t *testing.T) {
 	engineer, engineerCtx := svc.createUserCtx(t)
 	team := svc.createTeam(t, ctx, org)
 	err := svc.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-		TeamID:   team.ID,
-		Username: engineer.Username,
+		TeamID:    team.ID,
+		Usernames: []string{engineer.Username},
 	})
 	require.NoError(t, err)
 

--- a/internal/orgcreator/service.go
+++ b/internal/orgcreator/service.go
@@ -111,9 +111,9 @@ func (s *service) CreateOrganization(ctx context.Context, opts OrganizationCreat
 			return fmt.Errorf("creating owners team: %w", err)
 		}
 		err = s.AuthService.AddTeamMembership(ctx, auth.TeamMembershipOptions{
-			TeamID:   owners.ID,
-			Username: creator.Username,
-			Tx:       tx,
+			TeamID:    owners.ID,
+			Usernames: []string{creator.Username},
+			Tx:        tx,
 		})
 		if err != nil {
 			return fmt.Errorf("adding owner to owners team: %w", err)

--- a/internal/sql/pggen/agent_token.sql.go
+++ b/internal/sql/pggen/agent_token.sql.go
@@ -734,19 +734,19 @@ type Querier interface {
 	// DeleteTeamByIDScan scans the result of an executed DeleteTeamByIDBatch query.
 	DeleteTeamByIDScan(results pgx.BatchResults) (pgtype.Text, error)
 
-	InsertTeamMembership(ctx context.Context, username pgtype.Text, teamID pgtype.Text) (pgconn.CommandTag, error)
+	InsertTeamMembership(ctx context.Context, usernames []string, teamID pgtype.Text) ([]pgtype.Text, error)
 	// InsertTeamMembershipBatch enqueues a InsertTeamMembership query into batch to be executed
 	// later by the batch.
-	InsertTeamMembershipBatch(batch genericBatch, username pgtype.Text, teamID pgtype.Text)
+	InsertTeamMembershipBatch(batch genericBatch, usernames []string, teamID pgtype.Text)
 	// InsertTeamMembershipScan scans the result of an executed InsertTeamMembershipBatch query.
-	InsertTeamMembershipScan(results pgx.BatchResults) (pgconn.CommandTag, error)
+	InsertTeamMembershipScan(results pgx.BatchResults) ([]pgtype.Text, error)
 
-	DeleteTeamMembership(ctx context.Context, username pgtype.Text, teamID pgtype.Text) (pgtype.Text, error)
+	DeleteTeamMembership(ctx context.Context, usernames []string, teamID pgtype.Text) ([]pgtype.Text, error)
 	// DeleteTeamMembershipBatch enqueues a DeleteTeamMembership query into batch to be executed
 	// later by the batch.
-	DeleteTeamMembershipBatch(batch genericBatch, username pgtype.Text, teamID pgtype.Text)
+	DeleteTeamMembershipBatch(batch genericBatch, usernames []string, teamID pgtype.Text)
 	// DeleteTeamMembershipScan scans the result of an executed DeleteTeamMembershipBatch query.
-	DeleteTeamMembershipScan(results pgx.BatchResults) (pgtype.Text, error)
+	DeleteTeamMembershipScan(results pgx.BatchResults) ([]pgtype.Text, error)
 
 	InsertToken(ctx context.Context, params InsertTokenParams) (pgconn.CommandTag, error)
 	// InsertTokenBatch enqueues a InsertToken query into batch to be executed


### PR DESCRIPTION
Fixes #490 

Makes a breaking change to two CLI commands, permitting more than one user to be added/removed to/from a team:

`otf teams add-user [username]` -> `otf teams add-users [username|...]`
`otf teams del-user [username]` -> `otf teams del-users [username|...]`

Adds support for the following `tfe` provider resources:

* `tfe_team_member`
* `tfe_team_members`