### PR TITLE
feat: add tfe-api OAuth Client endpoints

### DIFF
--- a/hack/go-tfe-tests-upstream.bash
+++ b/hack/go-tfe-tests-upstream.bash
@@ -10,6 +10,9 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 
 export GO_TFE_REPO=github.com/hashicorp/go-tfe@latest
 
+# necessary for TestOAuthClients* tests
+export OAUTH_CLIENT_GITHUB_TOKEN="my-secret-github-token"
+
 tests=()
 tests+=('TestStateVersionOutputsRead')
 tests+=('TestOrganizationTagsList/with_no_query_params')
@@ -29,6 +32,9 @@ tests+=('TestNotificationConfigurationUpdate/^when')
 tests+=('TestTeamMembersAddByUsername')
 tests+=('TestTeamMembersRemoveByUsernames')
 tests+=('TestTeamMembersList')
+tests+=('TestOAuthClientsCreate$')
+tests+=('TestOAuthClientsRead')
+tests+=('TestOAuthClientsList')
 all=$(join_by '|' "${tests[@]}")
 
 ./hack/go-tfe-tests.bash $all

--- a/hack/go-tfe-tests-upstream.bash
+++ b/hack/go-tfe-tests-upstream.bash
@@ -35,6 +35,7 @@ tests+=('TestTeamMembersList')
 tests+=('TestOAuthClientsCreate$')
 tests+=('TestOAuthClientsRead')
 tests+=('TestOAuthClientsList')
+tests+=('TestOAuthClientsDelete')
 all=$(join_by '|' "${tests[@]}")
 
 ./hack/go-tfe-tests.bash $all

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/leg100/otf/internal/state"
 	"github.com/leg100/otf/internal/tokens"
 	"github.com/leg100/otf/internal/variable"
+	"github.com/leg100/otf/internal/vcsprovider"
 	"github.com/leg100/otf/internal/workspace"
 	"github.com/leg100/surl"
 )
@@ -32,6 +33,7 @@ type (
 		tokens.TokensService
 		variable.VariableService
 		notifications.NotificationService
+		vcsprovider.VCSProviderService
 
 		marshaler
 		internal.Verifier // for verifying signed urls
@@ -51,6 +53,7 @@ type (
 		tokens.TokensService
 		variable.VariableService
 		notifications.NotificationService
+		vcsprovider.VCSProviderService
 
 		*surl.Signer
 
@@ -71,6 +74,7 @@ func New(opts Options) *api {
 		TokensService:               opts.TokensService,
 		VariableService:             opts.VariableService,
 		NotificationService:         opts.NotificationService,
+		VCSProviderService:          opts.VCSProviderService,
 		marshaler: &jsonapiMarshaler{
 			OrganizationService: opts.OrganizationService,
 			WorkspaceService:    opts.WorkspaceService,
@@ -97,4 +101,5 @@ func (a *api) AddHandlers(r *mux.Router) {
 	a.addTokenHandlers(r)
 	a.addNotificationHandlers(r)
 	a.addOrganizationMembershipHandlers(r)
+	a.addOAuthClientHandlers(r)
 }

--- a/internal/api/marshaler.go
+++ b/internal/api/marshaler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/leg100/otf/internal/run"
 	"github.com/leg100/otf/internal/state"
 	"github.com/leg100/otf/internal/variable"
+	"github.com/leg100/otf/internal/vcsprovider"
 	"github.com/leg100/otf/internal/workspace"
 )
 
@@ -90,6 +91,10 @@ func (m *jsonapiMarshaler) writeResponse(w http.ResponseWriter, r *http.Request,
 		payload, marshalOpts, err = m.toTeam(v, r)
 	case *workspace.TagList:
 		payload, marshalOpts = m.toTags(v)
+	case *vcsprovider.VCSProvider:
+		payload = m.toOAuthClient(v)
+	case []*vcsprovider.VCSProvider:
+		payload = m.toOAuthClientList(v)
 	default:
 		Error(w, fmt.Errorf("cannot marshal unknown type: %T", v))
 		return

--- a/internal/api/oauth_client.go
+++ b/internal/api/oauth_client.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/leg100/otf/internal"
+	"github.com/leg100/otf/internal/vcsprovider"
+
+	"github.com/gorilla/mux"
+	"github.com/leg100/otf/internal/api/types"
+	otfhttp "github.com/leg100/otf/internal/http"
+	"github.com/leg100/otf/internal/http/decode"
+)
+
+const (
+	githubAPIURL  = "https://api.github.com"
+	githubHTTPURL = "https://github.com"
+)
+
+func (a *api) addOAuthClientHandlers(r *mux.Router) {
+	r = otfhttp.APIRouter(r)
+
+	r.HandleFunc("/organizations/{organization_name}/oauth-clients", a.createOAuthClient).Methods("POST")
+	r.HandleFunc("/organizations/{organization_name}/oauth-clients", a.listOAuthClients).Methods("GET")
+	r.HandleFunc("/oauth-clients/{oauth_client_id}", a.getOAuthClient).Methods("GET")
+	r.HandleFunc("/oauth-clients/{oauth_client_id}", a.deleteOAuthClient).Methods("DELETE")
+}
+
+func (a *api) createOAuthClient(w http.ResponseWriter, r *http.Request) {
+	org, err := decode.Param("organization_name", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	var params types.OAuthClientCreateOptions
+	if err := unmarshal(r.Body, &params); err != nil {
+		Error(w, err)
+		return
+	}
+
+	// required parameters
+	if params.OAuthToken == nil {
+		Error(w, &internal.MissingParameterError{Parameter: "oauth-token-string"})
+		return
+	}
+	if params.ServiceProvider == nil {
+		Error(w, &internal.MissingParameterError{Parameter: "service-provider"})
+		return
+	}
+	if params.APIURL == nil {
+		Error(w, &internal.MissingParameterError{Parameter: "api-url"})
+		return
+	}
+	if params.HTTPURL == nil {
+		Error(w, &internal.MissingParameterError{Parameter: "http-url"})
+		return
+	}
+
+	// unsupported parameters
+	if params.PrivateKey != nil {
+		Error(w, errors.New("private-key parameter is unsupported"))
+		return
+	}
+	if params.RSAPublicKey != nil {
+		Error(w, errors.New("rsa-public-key parameter is unsupported"))
+		return
+	}
+	if params.Secret != nil {
+		Error(w, errors.New("secret parameter is unsupported"))
+		return
+	}
+	if *params.ServiceProvider != types.ServiceProviderGithub {
+		Error(w, fmt.Errorf("service-provider=%s is unsupported", string(*params.ServiceProvider)))
+		return
+	}
+	if *params.APIURL != githubAPIURL {
+		Error(w, fmt.Errorf("only api-url=%s is supported", githubAPIURL))
+		return
+	}
+	if *params.HTTPURL != githubHTTPURL {
+		Error(w, fmt.Errorf("only http-url=%s is supported", string(*params.HTTPURL)))
+		return
+	}
+
+	// default parameters
+	if params.Name == nil {
+		params.Name = internal.String("")
+	}
+
+	oauthClient, err := a.CreateVCSProvider(r.Context(), vcsprovider.CreateOptions{
+		Name:         *params.Name,
+		Organization: org,
+		Token:        *params.OAuthToken,
+		Cloud:        "github",
+	})
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	a.writeResponse(w, r, oauthClient, withCode(http.StatusCreated))
+}
+
+func (a *api) listOAuthClients(w http.ResponseWriter, r *http.Request) {
+	org, err := decode.Param("organization_name", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	oauthClients, err := a.ListVCSProviders(r.Context(), org)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	a.writeResponse(w, r, oauthClients)
+}
+
+func (a *api) getOAuthClient(w http.ResponseWriter, r *http.Request) {
+	id, err := decode.Param("oauth_client_id", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	oauthClient, err := a.GetVCSProvider(r.Context(), id)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	a.writeResponse(w, r, oauthClient)
+}
+
+func (a *api) deleteOAuthClient(w http.ResponseWriter, r *http.Request) {
+	id, err := decode.Param("oauth_client_id", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	if _, err = a.DeleteVCSProvider(r.Context(), id); err != nil {
+		Error(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/oauth_client_marshaler.go
+++ b/internal/api/oauth_client_marshaler.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"github.com/leg100/otf/internal/api/types"
+	"github.com/leg100/otf/internal/vcsprovider"
+)
+
+func (m *jsonapiMarshaler) toOAuthClient(from *vcsprovider.VCSProvider) *types.OAuthClient {
+	to := &types.OAuthClient{
+		ID:        from.ID,
+		CreatedAt: from.CreatedAt,
+		// Only github via github.com is supported currently, so hardcode these values.
+		ServiceProvider: types.ServiceProviderGithub,
+		APIURL:          githubAPIURL,
+		HTTPURL:         githubHTTPURL,
+		// OTF has no corresponding concept of an OAuthToken, so just use the
+		// VCS provider ID (the go-tfe integration tests we use expect
+		// at least an ID).
+		OAuthTokens: []*types.OAuthToken{
+			{ID: from.ID},
+		},
+		Organization: &types.Organization{Name: from.Organization},
+	}
+	// A name is mandatory in OTF, but in go-tfe integration tests it is
+	// optional; therefore OTF takes an empty string to mean nil (this is
+	// necessary in order to pass the go-tfe integration tests).
+	if from.Name != "" {
+		to.Name = &from.Name
+	}
+	return to
+}
+
+func (m *jsonapiMarshaler) toOAuthClientList(from []*vcsprovider.VCSProvider) []*types.OAuthClient {
+	to := make([]*types.OAuthClient, len(from))
+	for i, fromProvider := range from {
+		to[i] = m.toOAuthClient(fromProvider)
+	}
+	return to
+}

--- a/internal/api/types/oauth_client.go
+++ b/internal/api/types/oauth_client.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import "time"
+
+// ServiceProviderType represents a VCS type.
+type ServiceProviderType string
+
+// List of available VCS types.
+const (
+	ServiceProviderAzureDevOpsServer   ServiceProviderType = "ado_server"
+	ServiceProviderAzureDevOpsServices ServiceProviderType = "ado_services"
+	ServiceProviderBitbucket           ServiceProviderType = "bitbucket_hosted"
+	// Bitbucket Server v5.4.0 and above
+	ServiceProviderBitbucketServer ServiceProviderType = "bitbucket_server"
+	// Bitbucket Server v5.3.0 and below
+	ServiceProviderBitbucketServerLegacy ServiceProviderType = "bitbucket_server_legacy"
+	ServiceProviderGithub                ServiceProviderType = "github"
+	ServiceProviderGithubEE              ServiceProviderType = "github_enterprise"
+	ServiceProviderGitlab                ServiceProviderType = "gitlab_hosted"
+	ServiceProviderGitlabCE              ServiceProviderType = "gitlab_community_edition"
+	ServiceProviderGitlabEE              ServiceProviderType = "gitlab_enterprise_edition"
+)
+
+// OAuthClient represents a connection between an organization and a VCS
+// provider.
+type OAuthClient struct {
+	ID                  string              `jsonapi:"primary,oauth-clients"`
+	APIURL              string              `jsonapi:"attribute" json:"api-url"`
+	CallbackURL         string              `jsonapi:"attribute" json:"callback-url"`
+	ConnectPath         string              `jsonapi:"attribute" json:"connect-path"`
+	CreatedAt           time.Time           `jsonapi:"attribute" json:"created-at"`
+	HTTPURL             string              `jsonapi:"attribute" json:"http-url"`
+	Key                 string              `jsonapi:"attribute" json:"key"`
+	RSAPublicKey        string              `jsonapi:"attribute" json:"rsa-public-key"`
+	Name                *string             `jsonapi:"attribute" json:"name"`
+	Secret              string              `jsonapi:"attribute" json:"secret"`
+	ServiceProvider     ServiceProviderType `jsonapi:"attribute" json:"service-provider"`
+	ServiceProviderName string              `jsonapi:"attribute" json:"service-provider-display-name"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relationship" json:"organization"`
+	OAuthTokens  []*OAuthToken `jsonapi:"relationship" json:"oauth-tokens"`
+}
+
+// OAuthClientCreateOptions represents the options for creating an OAuth client.
+type OAuthClientCreateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,oauth-clients"`
+
+	// A display name for the OAuth Client.
+	Name *string `jsonapi:"attribute" json:"name"`
+
+	// Required: The base URL of your VCS provider's API.
+	APIURL *string `jsonapi:"attribute" json:"api-url"`
+
+	// Required: The homepage of your VCS provider.
+	HTTPURL *string `jsonapi:"attribute" json:"http-url"`
+
+	// Optional: The OAuth Client key.
+	Key *string `jsonapi:"attribute" json:"key,omitempty"`
+
+	// Optional: The token string you were given by your VCS provider.
+	OAuthToken *string `jsonapi:"attribute" json:"oauth-token-string,omitempty"`
+
+	// Optional: Private key associated with this vcs provider - only available for ado_server
+	PrivateKey *string `jsonapi:"attribute" json:"private-key,omitempty"`
+
+	// Optional: Secret key associated with this vcs provider - only available for ado_server
+	Secret *string `jsonapi:"attribute" json:"secret,omitempty"`
+
+	// Optional: RSAPublicKey the text of the SSH public key associated with your BitBucket
+	// Server Application Link.
+	RSAPublicKey *string `jsonapi:"attribute" json:"rsa-public-key,omitempty"`
+
+	// Required: The VCS provider being connected with.
+	ServiceProvider *ServiceProviderType `jsonapi:"attribute" json:"service-provider"`
+}

--- a/internal/api/types/oauth_token.go
+++ b/internal/api/types/oauth_token.go
@@ -1,0 +1,16 @@
+package types
+
+import "time"
+
+// OAuthToken represents a VCS configuration including the associated
+// OAuth token
+type OAuthToken struct {
+	ID                  string    `jsonapi:"primary,oauth-tokens"`
+	UID                 string    `jsonapi:"attribute" json:"uid"`
+	CreatedAt           time.Time `jsonapi:"attribute" json:"created-at"`
+	HasSSHKey           bool      `jsonapi:"attribute" json:"has-ssh-key"`
+	ServiceProviderUser string    `jsonapi:"attribute" json:"service-provider-user"`
+
+	// Relations
+	OAuthClient *OAuthClient `jsonapi:"relationship" json:"oauth-client"`
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -293,6 +293,7 @@ func New(ctx context.Context, logger logr.Logger, cfg Config) (*Daemon, error) {
 		TeamService:                 authService,
 		VariableService:             variableService,
 		NotificationService:         notificationService,
+		VCSProviderService:          vcsProviderService,
 		Signer:                      signer,
 		MaxConfigSize:               cfg.MaxConfigSize,
 	})


### PR DESCRIPTION
Fixes #491 

Note: only adds support for Github for these endpoints. If using the `tfe` provider, then the following parameters are expected at minimum for the `tfe_oauth_client` resource:

```terraform
resource "tfe_oauth_client" "test" {
  api_url          = "https://api.github.com"
  http_url         = "https://github.com"
  service_provider = "github"
}
```