### PR TITLE
feat: pass go-tfe team integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ sql: install-pggen
 		--acronym vcs \
 		--acronym http \
 		--acronym tls \
+		--acronym sso \
 		--acronym hcl
 	goimports -w ./internal/sql/pggen
 	go fmt ./internal/sql/pggen

--- a/hack/go-tfe-tests-upstream.bash
+++ b/hack/go-tfe-tests-upstream.bash
@@ -36,6 +36,11 @@ tests+=('TestOAuthClientsCreate$')
 tests+=('TestOAuthClientsRead')
 tests+=('TestOAuthClientsList')
 tests+=('TestOAuthClientsDelete')
+tests+=('TestTeamsList')
+tests+=('TestTeamsCreate')
+tests+=('TestTeamsRead')
+tests+=('TestTeamsUpdate$')
+tests+=('TestTeamsDelete')
 all=$(join_by '|' "${tests[@]}")
 
 ./hack/go-tfe-tests.bash $all

--- a/internal/api/marshaler.go
+++ b/internal/api/marshaler.go
@@ -89,6 +89,8 @@ func (m *jsonapiMarshaler) writeResponse(w http.ResponseWriter, r *http.Request,
 		payload = m.toUser(v)
 	case *auth.Team:
 		payload, marshalOpts, err = m.toTeam(v, r)
+	case []*auth.Team:
+		payload, marshalOpts, err = m.toTeamList(v, r)
 	case *workspace.TagList:
 		payload, marshalOpts = m.toTags(v)
 	case *vcsprovider.VCSProvider:

--- a/internal/api/team.go
+++ b/internal/api/team.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -59,15 +58,8 @@ func (a *api) updateTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// unsupported parameters
-	if params.Visibility != nil && *params.Visibility != "organization" {
-		Error(w, fmt.Errorf("only organization visibility is supported"))
-		return
-	}
-
 	team, err := a.UpdateTeam(r.Context(), id, auth.UpdateTeamOptions{
-		Name:         *params.Name,
-		Organization: *params.Organization,
+		Name: params.Name,
 	})
 	if err != nil {
 		Error(w, err)

--- a/internal/api/team.go
+++ b/internal/api/team.go
@@ -14,8 +14,9 @@ func (a *api) addTeamHandlers(r *mux.Router) {
 	r = otfhttp.APIRouter(r)
 
 	r.HandleFunc("/organizations/{organization_name}/teams", a.createTeam).Methods("POST")
-	r.HandleFunc("/organizations/{organization_name}/teams/{team_name}", a.getTeam).Methods("GET")
-	r.HandleFunc("/teams/{team_id}", a.getTeamByID).Methods("GET")
+	r.HandleFunc("/organizations/{organization_name}/teams", a.listTeams).Methods("GET")
+	r.HandleFunc("/organizations/{organization_name}/teams/{team_name}", a.getTeamByName).Methods("GET")
+	r.HandleFunc("/teams/{team_id}", a.getTeam).Methods("GET")
 	r.HandleFunc("/teams/{team_id}", a.updateTeam).Methods("PATCH")
 	r.HandleFunc("/teams/{team_id}", a.deleteTeam).Methods("DELETE")
 }
@@ -33,10 +34,23 @@ func (a *api) createTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	team, err := a.CreateTeam(r.Context(), auth.CreateTeamOptions{
-		Name:         *params.Name,
-		Organization: org,
-	})
+	opts := auth.CreateTeamOptions{
+		Name:       params.Name,
+		SSOTeamID:  params.SSOTeamID,
+		Visibility: params.Visibility,
+	}
+	if params.OrganizationAccess != nil {
+		opts.OrganizationAccessOptions = auth.OrganizationAccessOptions{
+			ManageWorkspaces:      params.OrganizationAccess.ManageWorkspaces,
+			ManageVCS:             params.OrganizationAccess.ManageVCSSettings,
+			ManageModules:         params.OrganizationAccess.ManageModules,
+			ManageProviders:       params.OrganizationAccess.ManageProviders,
+			ManagePolicies:        params.OrganizationAccess.ManagePolicies,
+			ManagePolicyOverrides: params.OrganizationAccess.ManagePolicyOverrides,
+		}
+	}
+
+	team, err := a.CreateTeam(r.Context(), org, opts)
 	if err != nil {
 		Error(w, err)
 		return
@@ -58,9 +72,23 @@ func (a *api) updateTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	team, err := a.UpdateTeam(r.Context(), id, auth.UpdateTeamOptions{
-		Name: params.Name,
-	})
+	opts := auth.UpdateTeamOptions{
+		Name:       params.Name,
+		SSOTeamID:  params.SSOTeamID,
+		Visibility: params.Visibility,
+	}
+	if params.OrganizationAccess != nil {
+		opts.OrganizationAccessOptions = auth.OrganizationAccessOptions{
+			ManageWorkspaces:      params.OrganizationAccess.ManageWorkspaces,
+			ManageVCS:             params.OrganizationAccess.ManageVCSSettings,
+			ManageModules:         params.OrganizationAccess.ManageModules,
+			ManageProviders:       params.OrganizationAccess.ManageProviders,
+			ManagePolicies:        params.OrganizationAccess.ManagePolicies,
+			ManagePolicyOverrides: params.OrganizationAccess.ManagePolicyOverrides,
+		}
+	}
+
+	team, err := a.UpdateTeam(r.Context(), id, opts)
 	if err != nil {
 		Error(w, err)
 		return
@@ -69,7 +97,23 @@ func (a *api) updateTeam(w http.ResponseWriter, r *http.Request) {
 	a.writeResponse(w, r, team)
 }
 
-func (a *api) getTeam(w http.ResponseWriter, r *http.Request) {
+func (a *api) listTeams(w http.ResponseWriter, r *http.Request) {
+	organization, err := decode.Param("organization_name", r)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	team, err := a.ListTeams(r.Context(), organization)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	a.writeResponse(w, r, team)
+}
+
+func (a *api) getTeamByName(w http.ResponseWriter, r *http.Request) {
 	var params struct {
 		Organization *string `schema:"organization_name,required"`
 		Name         *string `schema:"team_name,required"`
@@ -88,7 +132,7 @@ func (a *api) getTeam(w http.ResponseWriter, r *http.Request) {
 	a.writeResponse(w, r, team)
 }
 
-func (a *api) getTeamByID(w http.ResponseWriter, r *http.Request) {
+func (a *api) getTeam(w http.ResponseWriter, r *http.Request) {
 	id, err := decode.Param("team_id", r)
 	if err != nil {
 		Error(w, err)

--- a/internal/api/team_marshaler.go
+++ b/internal/api/team_marshaler.go
@@ -5,14 +5,31 @@ import (
 	"strings"
 
 	"github.com/DataDog/jsonapi"
+	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/api/types"
 	"github.com/leg100/otf/internal/auth"
+	"github.com/leg100/otf/internal/http/decode"
 )
 
 func (m *jsonapiMarshaler) toTeam(from *auth.Team, r *http.Request) (*types.Team, []jsonapi.MarshalOption, error) {
 	to := &types.Team{
-		ID:   from.ID,
-		Name: from.Name,
+		ID:         from.ID,
+		Name:       from.Name,
+		SSOTeamID:  from.SSOTeamID,
+		Visibility: from.Visibility,
+		OrganizationAccess: &types.OrganizationAccess{
+			ManageWorkspaces:      from.Access.ManageWorkspaces,
+			ManageVCSSettings:     from.Access.ManageVCS,
+			ManageModules:         from.Access.ManageModules,
+			ManageProviders:       from.Access.ManageProviders,
+			ManagePolicies:        from.Access.ManagePolicies,
+			ManagePolicyOverrides: from.Access.ManagePolicyOverrides,
+		},
+		// Hardcode these values until proper support is added
+		Permissions: &types.TeamPermissions{
+			CanDestroy:          true,
+			CanUpdateMembership: true,
+		},
 	}
 
 	// Support including related resources:
@@ -36,5 +53,38 @@ func (m *jsonapiMarshaler) toTeam(from *auth.Team, r *http.Request) (*types.Team
 			}
 		}
 	}
+	return to, opts, nil
+}
+
+func (m *jsonapiMarshaler) toTeamList(from []*auth.Team, r *http.Request) (to []*types.Team, opts []jsonapi.MarshalOption, err error) {
+	var listOptions internal.ListOptions
+	if err := decode.All(&listOptions, r); err != nil {
+		return nil, nil, err
+	}
+	pagination := internal.NewPagination(listOptions, len(from))
+	opts = []jsonapi.MarshalOption{toMarshalOption(pagination)}
+
+	// trim the start
+	start := listOptions.SanitizedPageSize() * (listOptions.SanitizedPageNumber() - 1)
+	if start > len(from) {
+		// paging is out-of-range: return empty list
+		return to, opts, nil
+	}
+	from = from[start:]
+
+	// trim the end
+	end := listOptions.SanitizedPageSize() * listOptions.SanitizedPageNumber()
+	if len(from) > end {
+		from = from[:(end - 1)]
+	}
+
+	to = make([]*types.Team, len(from))
+	for i, fromTeam := range from {
+		to[i], _, err = m.toTeam(fromTeam, r)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	return to, opts, nil
 }

--- a/internal/api/types/pagination.go
+++ b/internal/api/types/pagination.go
@@ -1,5 +1,15 @@
 package types
 
+// ListOptions is used to specify pagination options when making API requests.
+// Pagination allows breaking up large result sets into chunks, or "pages".
+type ListOptions struct {
+	// The page number to request. The results vary based on the PageSize.
+	PageNumber int `url:"page[number],omitempty"`
+
+	// The number of elements returned in a single page.
+	PageSize int `url:"page[size],omitempty"`
+}
+
 // Pagination is used to return the pagination details of an API request.
 type Pagination struct {
 	CurrentPage  int  `json:"current-page"`

--- a/internal/api/types/team.go
+++ b/internal/api/types/team.go
@@ -36,13 +36,46 @@ type (
 		CanUpdateMembership bool `jsonapi:"attribute" json:"can-update-membership"`
 	}
 
-	// CreateTeamOptions represents the options for creating a
-	// user.
-	CreateTeamOptions struct {
-		Type               string                     `jsonapi:"primary,teams"`
-		Name               *string                    `jsonapi:"attribute" json:"name"`
-		Organization       *string                    `schema:"organization_name,required"`
+	// TeamCreateOptions represents the options for creating a team.
+	TeamCreateOptions struct {
+		// Type is a public field utilized by JSON:API to
+		// set the resource type via the field tag.
+		// It is not a user-defined value and does not need to be set.
+		// https://jsonapi.org/format/#crud-creating
+		Type string `jsonapi:"primary,teams"`
+
+		// Name of the team.
+		Name *string `jsonapi:"attribute" json:"name"`
+
+		// Optional: Unique Identifier to control team membership via SAML
+		SSOTeamID *string `jsonapi:"attribute" json:"sso-team-id,omitempty"`
+
+		// The team's organization access
 		OrganizationAccess *OrganizationAccessOptions `jsonapi:"attribute" json:"organization-access,omitempty"`
+
+		// The team's visibility ("secret", "organization")
+		Visibility *string `jsonapi:"attribute" json:"visibility,omitempty"`
+	}
+
+	// TeamUpdateOptions represents the options for updating a team.
+	TeamUpdateOptions struct {
+		// Type is a public field utilized by JSON:API to
+		// set the resource type via the field tag.
+		// It is not a user-defined value and does not need to be set.
+		// https://jsonapi.org/format/#crud-creating
+		Type string `jsonapi:"primary,teams"`
+
+		// Optional: New name for the team
+		Name *string `jsonapi:"attribute" json:"name,omitempty"`
+
+		// Optional: Unique Identifier to control team membership via SAML
+		SSOTeamID *string `jsonapi:"attribute" json:"sso-team-id,omitempty"`
+
+		// Optional: The team's organization access
+		OrganizationAccess *OrganizationAccessOptions `jsonapi:"attribute" json:"organization-access,omitempty"`
+
+		// Optional: The team's visibility ("secret", "organization")
+		Visibility *string `jsonapi:"attribute" json:"visibility,omitempty"`
 	}
 
 	// OrganizationAccessOptions represents the organization access options of a team.

--- a/internal/api/types/team.go
+++ b/internal/api/types/team.go
@@ -9,7 +9,7 @@ type (
 		Visibility         string              `jsonapi:"attribute" json:"visibility"`
 		Permissions        *TeamPermissions    `jsonapi:"attribute" json:"permissions"`
 		UserCount          int                 `jsonapi:"attribute" json:"users-count"`
-		SSOTeamID          string              `jsonapi:"attribute" json:"sso-team-id"`
+		SSOTeamID          *string             `jsonapi:"attribute" json:"sso-team-id"`
 
 		// Relations
 		Users []*User `jsonapi:"relationship" json:"users"`

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -84,10 +84,14 @@ func (c *Client) RemoveTeamMembership(ctx context.Context, opts TeamMembershipOp
 }
 
 // CreateTeam creates a team via HTTP/JSONAPI.
-func (c *Client) CreateTeam(ctx context.Context, opts CreateTeamOptions) (*Team, error) {
-	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(opts.Organization))
+func (c *Client) CreateTeam(ctx context.Context, organization string, opts CreateTeamOptions) (*Team, error) {
+	// validate params
+	if _, err := newTeam(organization, opts); err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
 	req, err := c.NewRequest("POST", u, &types.TeamCreateOptions{
-		Name: internal.String(opts.Name),
+		Name: opts.Name,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -86,7 +86,7 @@ func (c *Client) RemoveTeamMembership(ctx context.Context, opts TeamMembershipOp
 // CreateTeam creates a team via HTTP/JSONAPI.
 func (c *Client) CreateTeam(ctx context.Context, opts CreateTeamOptions) (*Team, error) {
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(opts.Organization))
-	req, err := c.NewRequest("POST", u, &types.CreateTeamOptions{
+	req, err := c.NewRequest("POST", u, &types.TeamCreateOptions{
 		Name: internal.String(opts.Name),
 	})
 	if err != nil {

--- a/internal/auth/db_row.go
+++ b/internal/auth/db_row.go
@@ -32,13 +32,18 @@ func (row userRow) toUser() *User {
 
 // teamRow represents the result of a database query for a team.
 type teamRow struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 func (row teamRow) toTeam() *Team {
@@ -50,7 +55,7 @@ func (row teamRow) toTeam() *Team {
 		Access: OrganizationAccess{
 			ManageWorkspaces: row.PermissionManageWorkspaces,
 			ManageVCS:        row.PermissionManageVCS,
-			ManageRegistry:   row.PermissionManageRegistry,
+			ManageModules:    row.PermissionManageModules,
 		},
 	}
 }

--- a/internal/auth/db_row.go
+++ b/internal/auth/db_row.go
@@ -47,15 +47,23 @@ type teamRow struct {
 }
 
 func (row teamRow) toTeam() *Team {
-	return &Team{
+	to := Team{
 		ID:           row.TeamID.String,
 		CreatedAt:    row.CreatedAt.Time.UTC(),
 		Name:         row.Name.String,
 		Organization: row.OrganizationName.String,
+		Visibility:   row.Visibility.String,
 		Access: OrganizationAccess{
-			ManageWorkspaces: row.PermissionManageWorkspaces,
-			ManageVCS:        row.PermissionManageVCS,
-			ManageModules:    row.PermissionManageModules,
+			ManageWorkspaces:      row.PermissionManageWorkspaces,
+			ManageVCS:             row.PermissionManageVCS,
+			ManageModules:         row.PermissionManageModules,
+			ManageProviders:       row.PermissionManageProviders,
+			ManagePolicies:        row.PermissionManagePolicies,
+			ManagePolicyOverrides: row.PermissionManagePolicyOverrides,
 		},
 	}
+	if row.SSOTeamID.Status == pgtype.Present {
+		to.SSOTeamID = &row.SSOTeamID.String
+	}
+	return &to
 }

--- a/internal/auth/team.go
+++ b/internal/auth/team.go
@@ -33,9 +33,9 @@ type (
 
 	// OrganizationAccess defines a team's organization access.
 	OrganizationAccess struct {
-		ManageWorkspaces bool `schema:"manage_workspaces"` // admin access on all workspaces
-		ManageVCS        bool `schema:"manage_vcs"`        // manage VCS providers
-		ManageModules    bool `schema:"manage_modules"`    // manage module registry
+		ManageWorkspaces bool // admin access on all workspaces
+		ManageVCS        bool // manage VCS providers
+		ManageModules    bool // manage module registry
 
 		// TFE fields that OTF does not support but persists merely to pass the
 		// go-tfe integration tests
@@ -44,12 +44,26 @@ type (
 		ManagePolicyOverrides bool
 	}
 
+	// OrganizationAccessOptions defines access to be granted upon team creation
+	// or to grant/rescind to/from an existing team.
+	OrganizationAccessOptions struct {
+		ManageWorkspaces *bool `schema:"manage_workspaces"`
+		ManageVCS        *bool `schema:"manage_vcs"`
+		ManageModules    *bool `schema:"manage_modules"`
+
+		// TFE fields that OTF does not support but persists merely to pass the
+		// go-tfe integration tests
+		ManageProviders       *bool
+		ManagePolicies        *bool
+		ManagePolicyOverrides *bool
+	}
+
 	UpdateTeamOptions struct {
 		Name       *string
 		SSOTeamID  *string
 		Visibility *string
 
-		OrganizationAccess
+		OrganizationAccessOptions
 	}
 )
 
@@ -71,11 +85,32 @@ func (t *Team) IsOwners() bool {
 }
 
 func (t *Team) Update(opts UpdateTeamOptions) error {
-	t.Access.ManageWorkspaces = opts.ManageWorkspaces
-	t.Access.ManageVCS = opts.ManageVCS
-	t.Access.ManageModules = opts.ManageModules
-	t.Access.ManageProviders = opts.ManageProviders
-	t.Access.ManagePolicies = opts.ManagePolicies
-	t.Access.ManagePolicyOverrides = opts.ManagePolicyOverrides
+	if opts.Name != nil {
+		t.Name = *opts.Name
+	}
+	if opts.SSOTeamID != nil {
+		t.SSOTeamID = opts.SSOTeamID
+	}
+	if opts.Visibility != nil {
+		t.Visibility = *opts.Visibility
+	}
+	if opts.ManageWorkspaces != nil {
+		t.Access.ManageWorkspaces = *opts.ManageWorkspaces
+	}
+	if opts.ManageVCS != nil {
+		t.Access.ManageVCS = *opts.ManageVCS
+	}
+	if opts.ManageModules != nil {
+		t.Access.ManageModules = *opts.ManageModules
+	}
+	if opts.ManageProviders != nil {
+		t.Access.ManageProviders = *opts.ManageProviders
+	}
+	if opts.ManagePolicies != nil {
+		t.Access.ManagePolicies = *opts.ManagePolicies
+	}
+	if opts.ManagePolicyOverrides != nil {
+		t.Access.ManagePolicyOverrides = *opts.ManagePolicyOverrides
+	}
 	return nil
 }

--- a/internal/auth/team.go
+++ b/internal/auth/team.go
@@ -15,6 +15,11 @@ type (
 		Organization string
 
 		Access OrganizationAccess
+
+		// TFE fields that OTF does not support but persists merely to pass the
+		// go-tfe integration tests
+		Visibility string
+		SSOTeamID  *string
 	}
 
 	CreateTeamOptions struct {
@@ -30,10 +35,20 @@ type (
 	OrganizationAccess struct {
 		ManageWorkspaces bool `schema:"manage_workspaces"` // admin access on all workspaces
 		ManageVCS        bool `schema:"manage_vcs"`        // manage VCS providers
-		ManageRegistry   bool `schema:"manage_registry"`   // manage module and provider registry
+		ManageModules    bool `schema:"manage_modules"`    // manage module registry
+
+		// TFE fields that OTF does not support but persists merely to pass the
+		// go-tfe integration tests
+		ManageProviders       bool
+		ManagePolicies        bool
+		ManagePolicyOverrides bool
 	}
 
 	UpdateTeamOptions struct {
+		Name       *string
+		SSOTeamID  *string
+		Visibility *string
+
 		OrganizationAccess
 	}
 )
@@ -58,6 +73,9 @@ func (t *Team) IsOwners() bool {
 func (t *Team) Update(opts UpdateTeamOptions) error {
 	t.Access.ManageWorkspaces = opts.ManageWorkspaces
 	t.Access.ManageVCS = opts.ManageVCS
-	t.Access.ManageRegistry = opts.ManageRegistry
+	t.Access.ManageModules = opts.ManageModules
+	t.Access.ManageProviders = opts.ManageProviders
+	t.Access.ManagePolicies = opts.ManagePolicies
+	t.Access.ManagePolicyOverrides = opts.ManagePolicyOverrides
 	return nil
 }

--- a/internal/auth/team_db.go
+++ b/internal/auth/team_db.go
@@ -8,12 +8,17 @@ import (
 )
 
 func (db *pgdb) createTeam(ctx context.Context, team *Team) error {
-	_, err := db.InsertTeam(ctx, pggen.InsertTeamParams{
+	params := pggen.InsertTeamParams{
 		ID:               sql.String(team.ID),
 		Name:             sql.String(team.Name),
 		CreatedAt:        sql.Timestamptz(team.CreatedAt),
 		OrganizationName: sql.String(team.Organization),
-	})
+		Visibility:       sql.String(team.Visibility),
+	}
+	if team.SSOTeamID != nil {
+		params.SSOTeamID = sql.String(*team.SSOTeamID)
+	}
+	_, err := db.InsertTeam(ctx, params)
 	return sql.Error(err)
 }
 
@@ -39,6 +44,7 @@ func (db *pgdb) UpdateTeam(ctx context.Context, teamID string, fn func(*Team) er
 			PermissionManageVCS:        team.OrganizationAccess().ManageVCS,
 			PermissionManageModules:    team.OrganizationAccess().ManageModules,
 			TeamID:                     sql.String(teamID),
+			Visibility:                 sql.String(team.Visibility),
 		})
 		if err != nil {
 			return err

--- a/internal/auth/team_db.go
+++ b/internal/auth/team_db.go
@@ -37,7 +37,7 @@ func (db *pgdb) UpdateTeam(ctx context.Context, teamID string, fn func(*Team) er
 		_, err = tx.UpdateTeamByID(ctx, pggen.UpdateTeamByIDParams{
 			PermissionManageWorkspaces: team.OrganizationAccess().ManageWorkspaces,
 			PermissionManageVCS:        team.OrganizationAccess().ManageVCS,
-			PermissionManageRegistry:   team.OrganizationAccess().ManageRegistry,
+			PermissionManageModules:    team.OrganizationAccess().ManageModules,
 			TeamID:                     sql.String(teamID),
 		})
 		if err != nil {

--- a/internal/auth/team_db.go
+++ b/internal/auth/team_db.go
@@ -8,17 +8,20 @@ import (
 )
 
 func (db *pgdb) createTeam(ctx context.Context, team *Team) error {
-	params := pggen.InsertTeamParams{
-		ID:               sql.String(team.ID),
-		Name:             sql.String(team.Name),
-		CreatedAt:        sql.Timestamptz(team.CreatedAt),
-		OrganizationName: sql.String(team.Organization),
-		Visibility:       sql.String(team.Visibility),
-	}
-	if team.SSOTeamID != nil {
-		params.SSOTeamID = sql.String(*team.SSOTeamID)
-	}
-	_, err := db.InsertTeam(ctx, params)
+	_, err := db.InsertTeam(ctx, pggen.InsertTeamParams{
+		ID:                              sql.String(team.ID),
+		Name:                            sql.String(team.Name),
+		CreatedAt:                       sql.Timestamptz(team.CreatedAt),
+		OrganizationName:                sql.String(team.Organization),
+		Visibility:                      sql.String(team.Visibility),
+		SSOTeamID:                       sql.StringPtr(team.SSOTeamID),
+		PermissionManageWorkspaces:      team.Access.ManageWorkspaces,
+		PermissionManageVCS:             team.Access.ManageVCS,
+		PermissionManageModules:         team.Access.ManageModules,
+		PermissionManageProviders:       team.Access.ManageProviders,
+		PermissionManagePolicies:        team.Access.ManagePolicies,
+		PermissionManagePolicyOverrides: team.Access.ManagePolicyOverrides,
+	})
 	return sql.Error(err)
 }
 
@@ -40,11 +43,16 @@ func (db *pgdb) UpdateTeam(ctx context.Context, teamID string, fn func(*Team) er
 		}
 		// persist update
 		_, err = tx.UpdateTeamByID(ctx, pggen.UpdateTeamByIDParams{
-			PermissionManageWorkspaces: team.OrganizationAccess().ManageWorkspaces,
-			PermissionManageVCS:        team.OrganizationAccess().ManageVCS,
-			PermissionManageModules:    team.OrganizationAccess().ManageModules,
-			TeamID:                     sql.String(teamID),
-			Visibility:                 sql.String(team.Visibility),
+			TeamID:                          sql.String(teamID),
+			Name:                            sql.String(team.Name),
+			Visibility:                      sql.String(team.Visibility),
+			SSOTeamID:                       sql.StringPtr(team.SSOTeamID),
+			PermissionManageWorkspaces:      team.Access.ManageWorkspaces,
+			PermissionManageVCS:             team.Access.ManageVCS,
+			PermissionManageModules:         team.Access.ManageModules,
+			PermissionManageProviders:       team.Access.ManageProviders,
+			PermissionManagePolicies:        team.Access.ManagePolicies,
+			PermissionManagePolicyOverrides: team.Access.ManagePolicyOverrides,
 		})
 		if err != nil {
 			return err

--- a/internal/auth/team_test_helpers.go
+++ b/internal/auth/team_test_helpers.go
@@ -12,7 +12,11 @@ import (
 )
 
 func NewTestTeam(t *testing.T, organization string) *Team {
-	return NewTeam(CreateTeamOptions{uuid.NewString(), organization, nil})
+	team, err := newTeam(organization, CreateTeamOptions{
+		Name: internal.String(uuid.NewString()),
+	})
+	require.NoError(t, err)
+	return team
 }
 
 func CreateTestTeam(t *testing.T, db internal.DB, organization *organization.Organization) *Team {
@@ -34,5 +38,9 @@ func createTestTeam(t *testing.T, db *pgdb, organization string) *Team {
 }
 
 func newTestOwners(t *testing.T, organization string) *Team {
-	return NewTeam(CreateTeamOptions{"owners", organization, nil})
+	team, err := newTeam(organization, CreateTeamOptions{
+		Name: internal.String("owners"),
+	})
+	require.NoError(t, err)
+	return team
 }

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -149,7 +149,7 @@ func (u *User) CanAccessOrganization(action rbac.Action, org string) bool {
 					return true
 				}
 			}
-			if team.Access.ManageRegistry {
+			if team.Access.ManageModules {
 				if rbac.VCSManagerRole.IsAllowed(action) {
 					return true
 				}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/auth"
 	"github.com/spf13/cobra"
 )
@@ -31,9 +32,8 @@ func (a *CLI) teamNewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			team, err := a.CreateTeam(cmd.Context(), auth.CreateTeamOptions{
-				Organization: organization,
-				Name:         args[0],
+			team, err := a.CreateTeam(cmd.Context(), organization, auth.CreateTeamOptions{
+				Name: internal.String(args[0]),
 			})
 			if err != nil {
 				return err

--- a/internal/cli/test_helpers.go
+++ b/internal/cli/test_helpers.go
@@ -118,7 +118,7 @@ func (f *fakeClient) RemoveTeamMembership(context.Context, auth.TeamMembershipOp
 	return nil
 }
 
-func (f *fakeClient) CreateTeam(context.Context, auth.CreateTeamOptions) (*auth.Team, error) {
+func (f *fakeClient) CreateTeam(context.Context, string, auth.CreateTeamOptions) (*auth.Team, error) {
 	return f.team, nil
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -72,7 +72,7 @@ type (
 		AddTeamMembership(ctx context.Context, opts auth.TeamMembershipOptions) error
 		RemoveTeamMembership(ctx context.Context, opts auth.TeamMembershipOptions) error
 
-		CreateTeam(ctx context.Context, opts auth.CreateTeamOptions) (*auth.Team, error)
+		CreateTeam(ctx context.Context, organization string, opts auth.CreateTeamOptions) (*auth.Team, error)
 		GetTeam(ctx context.Context, organization, team string) (*auth.Team, error)
 		DeleteTeam(ctx context.Context, teamID string) error
 

--- a/internal/http/html/static/templates/content/team_get.tmpl
+++ b/internal/http/html/static/templates/content/team_get.tmpl
@@ -41,13 +41,13 @@
     <div class="field">
       <input
         type="checkbox"
-        name="manage_registry"
-        id="manage_registry"
+        name="manage_modules"
+        id="manage_modules"
         value="true"
-        {{ if or .Team.OrganizationAccess.ManageRegistry .Team.IsOwners }}checked{{ end }}
+        {{ if or .Team.OrganizationAccess.ManageModules .Team.IsOwners }}checked{{ end }}
         {{ if or (not $canSetPermission) .Team.IsOwners }}disabled{{ end }}
       >
-      <label for="manage_registry">Manage Registry: Allows members to publish and delete modules within the organization.</label>
+      <label for="manage_modules">Manage Modules: Allows members to publish and delete modules within the organization.</label>
     </div>
     <div class="field">
       <button

--- a/internal/integration/daemon_helpers_test.go
+++ b/internal/integration/daemon_helpers_test.go
@@ -249,9 +249,8 @@ func (s *testDaemon) createTeam(t *testing.T, ctx context.Context, org *organiza
 		org = s.createOrganization(t, ctx)
 	}
 
-	team, err := s.CreateTeam(ctx, auth.CreateTeamOptions{
-		Name:         "team-" + internal.GenerateRandomString(4),
-		Organization: org.Name,
+	team, err := s.CreateTeam(ctx, org.Name, auth.CreateTeamOptions{
+		Name: internal.String("team-" + internal.GenerateRandomString(4)),
 	})
 	require.NoError(t, err)
 	return team

--- a/internal/integration/team_service_test.go
+++ b/internal/integration/team_service_test.go
@@ -16,16 +16,14 @@ func TestIntegation_TeamService(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
 		svc, org, ctx := setup(t, nil)
 
-		team, err := svc.CreateTeam(ctx, auth.CreateTeamOptions{
-			Name:         uuid.NewString(),
-			Organization: org.Name,
+		team, err := svc.CreateTeam(ctx, org.Name, auth.CreateTeamOptions{
+			Name: internal.String(uuid.NewString()),
 		})
 		require.NoError(t, err)
 
 		t.Run("already exists error", func(t *testing.T) {
-			_, err := svc.CreateTeam(ctx, auth.CreateTeamOptions{
-				Name:         team.Name,
-				Organization: org.Name,
+			_, err := svc.CreateTeam(ctx, org.Name, auth.CreateTeamOptions{
+				Name: internal.String(team.Name),
 			})
 			require.Equal(t, internal.ErrResourceAlreadyExists, err)
 		})

--- a/internal/integration/team_service_test.go
+++ b/internal/integration/team_service_test.go
@@ -39,7 +39,7 @@ func TestIntegation_TeamService(t *testing.T) {
 			OrganizationAccess: auth.OrganizationAccess{
 				ManageWorkspaces: true,
 				ManageVCS:        true,
-				ManageRegistry:   true,
+				ManageModules:    true,
 			},
 		})
 		require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestIntegation_TeamService(t *testing.T) {
 
 		assert.True(t, got.OrganizationAccess().ManageWorkspaces)
 		assert.True(t, got.OrganizationAccess().ManageVCS)
-		assert.True(t, got.OrganizationAccess().ManageRegistry)
+		assert.True(t, got.OrganizationAccess().ManageModules)
 	})
 
 	t.Run("get", func(t *testing.T) {

--- a/internal/integration/team_service_test.go
+++ b/internal/integration/team_service_test.go
@@ -36,10 +36,10 @@ func TestIntegation_TeamService(t *testing.T) {
 		team := svc.createTeam(t, ctx, nil)
 
 		_, err := svc.UpdateTeam(ctx, team.ID, auth.UpdateTeamOptions{
-			OrganizationAccess: auth.OrganizationAccess{
-				ManageWorkspaces: true,
-				ManageVCS:        true,
-				ManageModules:    true,
+			OrganizationAccessOptions: auth.OrganizationAccessOptions{
+				ManageWorkspaces: internal.Bool(true),
+				ManageVCS:        internal.Bool(true),
+				ManageModules:    internal.Bool(true),
 			},
 		})
 		require.NoError(t, err)

--- a/internal/integration/web_test.go
+++ b/internal/integration/web_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/chromedp/chromedp"
+	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/auth"
 	"github.com/stretchr/testify/require"
 )
@@ -16,9 +17,8 @@ func TestWeb(t *testing.T) {
 	daemon, org, ctx := setup(t, nil)
 	user := userFromContext(t, ctx)
 
-	team, err := daemon.CreateTeam(ctx, auth.CreateTeamOptions{
-		Organization: org.Name,
-		Name:         "devops",
+	team, err := daemon.CreateTeam(ctx, org.Name, auth.CreateTeamOptions{
+		Name: internal.String("devops"),
 	})
 	require.NoError(t, err)
 	err = daemon.AddTeamMembership(ctx, auth.TeamMembershipOptions{

--- a/internal/orgcreator/service.go
+++ b/internal/orgcreator/service.go
@@ -102,10 +102,9 @@ func (s *service) CreateOrganization(ctx context.Context, opts OrganizationCreat
 			Organization: *opts.Name,
 		})
 
-		owners, err := s.AuthService.CreateTeam(ctx, auth.CreateTeamOptions{
-			Name:         "owners",
-			Organization: org.Name,
-			Tx:           tx,
+		owners, err := s.AuthService.CreateTeam(ctx, org.Name, auth.CreateTeamOptions{
+			Name: internal.String("owners"),
+			Tx:   tx,
 		})
 		if err != nil {
 			return fmt.Errorf("creating owners team: %w", err)

--- a/internal/sql/migrations/20230630180152_add_tfe_columns_to_team.sql
+++ b/internal/sql/migrations/20230630180152_add_tfe_columns_to_team.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+ALTER TABLE teams
+    ADD COLUMN sso_team_id TEXT,
+    ADD COLUMN visibility TEXT NOT NULL DEFAULT 'secret',
+    ADD COLUMN permission_manage_policies BOOL NOT NULL DEFAULT FALSE,
+    ADD COLUMN permission_manage_policy_overrides BOOL NOT NULL DEFAULT FALSE,
+    ADD COLUMN permission_manage_providers BOOL NOT NULL DEFAULT FALSE;
+ALTER TABLE teams
+    RENAME COLUMN permission_manage_registry TO permission_manage_modules;
+
+-- +goose Down
+ALTER TABLE teams
+    DROP COLUMN sso_team_id,
+    DROP COLUMN visibility,
+    DROP COLUMN permission_manage_policies,
+    DROP COLUMN permission_manage_policy_overrides,
+    DROP COLUMN permission_manage_providers;
+ALTER TABLE teams
+    RENAME COLUMN permission_manage_modules TO permission_manage_registry;

--- a/internal/sql/pggen/agent_token.sql.go
+++ b/internal/sql/pggen/agent_token.sql.go
@@ -1715,13 +1715,18 @@ type StateVersionOutputs struct {
 
 // Teams represents the Postgres composite type "teams".
 type Teams struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 // Users represents the Postgres composite type "users".
@@ -1961,8 +1966,13 @@ func (tr *typeResolver) newTeams() pgtype.ValueTranscoder {
 		compositeField{"created_at", "timestamptz", &pgtype.Timestamptz{}},
 		compositeField{"permission_manage_workspaces", "bool", &pgtype.Bool{}},
 		compositeField{"permission_manage_vcs", "bool", &pgtype.Bool{}},
-		compositeField{"permission_manage_registry", "bool", &pgtype.Bool{}},
+		compositeField{"permission_manage_modules", "bool", &pgtype.Bool{}},
 		compositeField{"organization_name", "text", &pgtype.Text{}},
+		compositeField{"sso_team_id", "text", &pgtype.Text{}},
+		compositeField{"visibility", "text", &pgtype.Text{}},
+		compositeField{"permission_manage_policies", "bool", &pgtype.Bool{}},
+		compositeField{"permission_manage_policy_overrides", "bool", &pgtype.Bool{}},
+		compositeField{"permission_manage_providers", "bool", &pgtype.Bool{}},
 	)
 }
 

--- a/internal/sql/pggen/team.sql.go
+++ b/internal/sql/pggen/team.sql.go
@@ -15,25 +15,49 @@ const insertTeamSQL = `INSERT INTO teams (
     team_id,
     name,
     created_at,
-    organization_name
+    organization_name,
+    visibility,
+    sso_team_id,
+    permission_manage_workspaces,
+    permission_manage_vcs,
+    permission_manage_modules,
+    permission_manage_providers,
+    permission_manage_policies,
+    permission_manage_policy_overrides
 ) VALUES (
     $1,
     $2,
     $3,
-    $4
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10,
+    $11,
+    $12
 );`
 
 type InsertTeamParams struct {
-	ID               pgtype.Text
-	Name             pgtype.Text
-	CreatedAt        pgtype.Timestamptz
-	OrganizationName pgtype.Text
+	ID                              pgtype.Text
+	Name                            pgtype.Text
+	CreatedAt                       pgtype.Timestamptz
+	OrganizationName                pgtype.Text
+	Visibility                      pgtype.Text
+	SSOTeamID                       pgtype.Text
+	PermissionManageWorkspaces      bool
+	PermissionManageVCS             bool
+	PermissionManageModules         bool
+	PermissionManageProviders       bool
+	PermissionManagePolicies        bool
+	PermissionManagePolicyOverrides bool
 }
 
 // InsertTeam implements Querier.InsertTeam.
 func (q *DBQuerier) InsertTeam(ctx context.Context, params InsertTeamParams) (pgconn.CommandTag, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "InsertTeam")
-	cmdTag, err := q.conn.Exec(ctx, insertTeamSQL, params.ID, params.Name, params.CreatedAt, params.OrganizationName)
+	cmdTag, err := q.conn.Exec(ctx, insertTeamSQL, params.ID, params.Name, params.CreatedAt, params.OrganizationName, params.Visibility, params.SSOTeamID, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageModules, params.PermissionManageProviders, params.PermissionManagePolicies, params.PermissionManagePolicyOverrides)
 	if err != nil {
 		return cmdTag, fmt.Errorf("exec query InsertTeam: %w", err)
 	}
@@ -42,7 +66,7 @@ func (q *DBQuerier) InsertTeam(ctx context.Context, params InsertTeamParams) (pg
 
 // InsertTeamBatch implements Querier.InsertTeamBatch.
 func (q *DBQuerier) InsertTeamBatch(batch genericBatch, params InsertTeamParams) {
-	batch.Queue(insertTeamSQL, params.ID, params.Name, params.CreatedAt, params.OrganizationName)
+	batch.Queue(insertTeamSQL, params.ID, params.Name, params.CreatedAt, params.OrganizationName, params.Visibility, params.SSOTeamID, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageModules, params.PermissionManageProviders, params.PermissionManagePolicies, params.PermissionManagePolicyOverrides)
 }
 
 // InsertTeamScan implements Querier.InsertTeamScan.
@@ -60,13 +84,18 @@ WHERE organization_name = $1
 ;`
 
 type FindTeamsByOrgRow struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 // FindTeamsByOrg implements Querier.FindTeamsByOrg.
@@ -80,7 +109,7 @@ func (q *DBQuerier) FindTeamsByOrg(ctx context.Context, organizationName pgtype.
 	items := []FindTeamsByOrgRow{}
 	for rows.Next() {
 		var item FindTeamsByOrgRow
-		if err := rows.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+		if err := rows.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 			return nil, fmt.Errorf("scan FindTeamsByOrg row: %w", err)
 		}
 		items = append(items, item)
@@ -106,7 +135,7 @@ func (q *DBQuerier) FindTeamsByOrgScan(results pgx.BatchResults) ([]FindTeamsByO
 	items := []FindTeamsByOrgRow{}
 	for rows.Next() {
 		var item FindTeamsByOrgRow
-		if err := rows.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+		if err := rows.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 			return nil, fmt.Errorf("scan FindTeamsByOrgBatch row: %w", err)
 		}
 		items = append(items, item)
@@ -124,13 +153,18 @@ AND   organization_name = $2
 ;`
 
 type FindTeamByNameRow struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 // FindTeamByName implements Querier.FindTeamByName.
@@ -138,7 +172,7 @@ func (q *DBQuerier) FindTeamByName(ctx context.Context, name pgtype.Text, organi
 	ctx = context.WithValue(ctx, "pggen_query_name", "FindTeamByName")
 	row := q.conn.QueryRow(ctx, findTeamByNameSQL, name, organizationName)
 	var item FindTeamByNameRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("query FindTeamByName: %w", err)
 	}
 	return item, nil
@@ -153,7 +187,7 @@ func (q *DBQuerier) FindTeamByNameBatch(batch genericBatch, name pgtype.Text, or
 func (q *DBQuerier) FindTeamByNameScan(results pgx.BatchResults) (FindTeamByNameRow, error) {
 	row := results.QueryRow()
 	var item FindTeamByNameRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("scan FindTeamByNameBatch row: %w", err)
 	}
 	return item, nil
@@ -165,13 +199,18 @@ WHERE team_id = $1
 ;`
 
 type FindTeamByIDRow struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 // FindTeamByID implements Querier.FindTeamByID.
@@ -179,7 +218,7 @@ func (q *DBQuerier) FindTeamByID(ctx context.Context, teamID pgtype.Text) (FindT
 	ctx = context.WithValue(ctx, "pggen_query_name", "FindTeamByID")
 	row := q.conn.QueryRow(ctx, findTeamByIDSQL, teamID)
 	var item FindTeamByIDRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("query FindTeamByID: %w", err)
 	}
 	return item, nil
@@ -194,7 +233,7 @@ func (q *DBQuerier) FindTeamByIDBatch(batch genericBatch, teamID pgtype.Text) {
 func (q *DBQuerier) FindTeamByIDScan(results pgx.BatchResults) (FindTeamByIDRow, error) {
 	row := results.QueryRow()
 	var item FindTeamByIDRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("scan FindTeamByIDBatch row: %w", err)
 	}
 	return item, nil
@@ -207,13 +246,18 @@ FOR UPDATE OF t
 ;`
 
 type FindTeamByIDForUpdateRow struct {
-	TeamID                     pgtype.Text        `json:"team_id"`
-	Name                       pgtype.Text        `json:"name"`
-	CreatedAt                  pgtype.Timestamptz `json:"created_at"`
-	PermissionManageWorkspaces bool               `json:"permission_manage_workspaces"`
-	PermissionManageVCS        bool               `json:"permission_manage_vcs"`
-	PermissionManageRegistry   bool               `json:"permission_manage_registry"`
-	OrganizationName           pgtype.Text        `json:"organization_name"`
+	TeamID                          pgtype.Text        `json:"team_id"`
+	Name                            pgtype.Text        `json:"name"`
+	CreatedAt                       pgtype.Timestamptz `json:"created_at"`
+	PermissionManageWorkspaces      bool               `json:"permission_manage_workspaces"`
+	PermissionManageVCS             bool               `json:"permission_manage_vcs"`
+	PermissionManageModules         bool               `json:"permission_manage_modules"`
+	OrganizationName                pgtype.Text        `json:"organization_name"`
+	SSOTeamID                       pgtype.Text        `json:"sso_team_id"`
+	Visibility                      pgtype.Text        `json:"visibility"`
+	PermissionManagePolicies        bool               `json:"permission_manage_policies"`
+	PermissionManagePolicyOverrides bool               `json:"permission_manage_policy_overrides"`
+	PermissionManageProviders       bool               `json:"permission_manage_providers"`
 }
 
 // FindTeamByIDForUpdate implements Querier.FindTeamByIDForUpdate.
@@ -221,7 +265,7 @@ func (q *DBQuerier) FindTeamByIDForUpdate(ctx context.Context, teamID pgtype.Tex
 	ctx = context.WithValue(ctx, "pggen_query_name", "FindTeamByIDForUpdate")
 	row := q.conn.QueryRow(ctx, findTeamByIDForUpdateSQL, teamID)
 	var item FindTeamByIDForUpdateRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("query FindTeamByIDForUpdate: %w", err)
 	}
 	return item, nil
@@ -236,7 +280,7 @@ func (q *DBQuerier) FindTeamByIDForUpdateBatch(batch genericBatch, teamID pgtype
 func (q *DBQuerier) FindTeamByIDForUpdateScan(results pgx.BatchResults) (FindTeamByIDForUpdateRow, error) {
 	row := results.QueryRow()
 	var item FindTeamByIDForUpdateRow
-	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageRegistry, &item.OrganizationName); err != nil {
+	if err := row.Scan(&item.TeamID, &item.Name, &item.CreatedAt, &item.PermissionManageWorkspaces, &item.PermissionManageVCS, &item.PermissionManageModules, &item.OrganizationName, &item.SSOTeamID, &item.Visibility, &item.PermissionManagePolicies, &item.PermissionManagePolicyOverrides, &item.PermissionManageProviders); err != nil {
 		return item, fmt.Errorf("scan FindTeamByIDForUpdateBatch row: %w", err)
 	}
 	return item, nil
@@ -244,23 +288,35 @@ func (q *DBQuerier) FindTeamByIDForUpdateScan(results pgx.BatchResults) (FindTea
 
 const updateTeamByIDSQL = `UPDATE teams
 SET
-    permission_manage_workspaces = $1,
-    permission_manage_vcs = $2,
-    permission_manage_registry = $3
-WHERE team_id = $4
+    name = $1,
+    visibility = $2,
+    sso_team_id = $3,
+    permission_manage_workspaces = $4,
+    permission_manage_vcs = $5,
+    permission_manage_modules = $6,
+    permission_manage_providers = $7,
+    permission_manage_policies = $8,
+    permission_manage_policy_overrides = $9
+WHERE team_id = $10
 RETURNING team_id;`
 
 type UpdateTeamByIDParams struct {
-	PermissionManageWorkspaces bool
-	PermissionManageVCS        bool
-	PermissionManageRegistry   bool
-	TeamID                     pgtype.Text
+	Name                            pgtype.Text
+	Visibility                      pgtype.Text
+	SSOTeamID                       pgtype.Text
+	PermissionManageWorkspaces      bool
+	PermissionManageVCS             bool
+	PermissionManageModules         bool
+	PermissionManageProviders       bool
+	PermissionManagePolicies        bool
+	PermissionManagePolicyOverrides bool
+	TeamID                          pgtype.Text
 }
 
 // UpdateTeamByID implements Querier.UpdateTeamByID.
 func (q *DBQuerier) UpdateTeamByID(ctx context.Context, params UpdateTeamByIDParams) (pgtype.Text, error) {
 	ctx = context.WithValue(ctx, "pggen_query_name", "UpdateTeamByID")
-	row := q.conn.QueryRow(ctx, updateTeamByIDSQL, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageRegistry, params.TeamID)
+	row := q.conn.QueryRow(ctx, updateTeamByIDSQL, params.Name, params.Visibility, params.SSOTeamID, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageModules, params.PermissionManageProviders, params.PermissionManagePolicies, params.PermissionManagePolicyOverrides, params.TeamID)
 	var item pgtype.Text
 	if err := row.Scan(&item); err != nil {
 		return item, fmt.Errorf("query UpdateTeamByID: %w", err)
@@ -270,7 +326,7 @@ func (q *DBQuerier) UpdateTeamByID(ctx context.Context, params UpdateTeamByIDPar
 
 // UpdateTeamByIDBatch implements Querier.UpdateTeamByIDBatch.
 func (q *DBQuerier) UpdateTeamByIDBatch(batch genericBatch, params UpdateTeamByIDParams) {
-	batch.Queue(updateTeamByIDSQL, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageRegistry, params.TeamID)
+	batch.Queue(updateTeamByIDSQL, params.Name, params.Visibility, params.SSOTeamID, params.PermissionManageWorkspaces, params.PermissionManageVCS, params.PermissionManageModules, params.PermissionManageProviders, params.PermissionManagePolicies, params.PermissionManagePolicyOverrides, params.TeamID)
 }
 
 // UpdateTeamByIDScan implements Querier.UpdateTeamByIDScan.

--- a/internal/sql/queries/team.sql
+++ b/internal/sql/queries/team.sql
@@ -3,12 +3,28 @@ INSERT INTO teams (
     team_id,
     name,
     created_at,
-    organization_name
+    organization_name,
+    visibility,
+    sso_team_id,
+    permission_manage_workspaces,
+    permission_manage_vcs,
+    permission_manage_modules,
+    permission_manage_providers,
+    permission_manage_policies,
+    permission_manage_policy_overrides
 ) VALUES (
     pggen.arg('id'),
     pggen.arg('name'),
     pggen.arg('created_at'),
-    pggen.arg('organization_name')
+    pggen.arg('organization_name'),
+    pggen.arg('visibility'),
+    pggen.arg('sso_team_id'),
+    pggen.arg('permission_manage_workspaces'),
+    pggen.arg('permission_manage_vcs'),
+    pggen.arg('permission_manage_modules'),
+    pggen.arg('permission_manage_providers'),
+    pggen.arg('permission_manage_policies'),
+    pggen.arg('permission_manage_policy_overrides')
 );
 
 -- name: FindTeamsByOrg :many
@@ -40,9 +56,15 @@ FOR UPDATE OF t
 -- name: UpdateTeamByID :one
 UPDATE teams
 SET
+    name = pggen.arg('name'),
+    visibility = pggen.arg('visibility'),
+    sso_team_id = pggen.arg('sso_team_id'),
     permission_manage_workspaces = pggen.arg('permission_manage_workspaces'),
     permission_manage_vcs = pggen.arg('permission_manage_vcs'),
-    permission_manage_registry = pggen.arg('permission_manage_registry')
+    permission_manage_modules = pggen.arg('permission_manage_modules'),
+    permission_manage_providers = pggen.arg('permission_manage_providers'),
+    permission_manage_policies = pggen.arg('permission_manage_policies'),
+    permission_manage_policy_overrides = pggen.arg('permission_manage_policy_overrides')
 WHERE team_id = pggen.arg('team_id')
 RETURNING team_id;
 

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -19,6 +19,14 @@ func String(s string) pgtype.Text {
 	return pgtype.Text{String: s, Status: pgtype.Present}
 }
 
+// StringPtr converts a go-string pointer into a postgres nullable string
+func StringPtr(s *string) pgtype.Text {
+	if s != nil {
+		return pgtype.Text{String: *s, Status: pgtype.Present}
+	}
+	return pgtype.Text{Status: pgtype.Null}
+}
+
 // NullString returns a postgres null string
 func NullString() pgtype.Text {
 	return pgtype.Text{Status: pgtype.Null}


### PR DESCRIPTION
This PR introduces everything necessary to ensure OTF passes the integration tests for the Teams API. This includes:

* adding further Teams API endpoints to complete the [documented list](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams)
* adding a bunch of fields to the `Team` type and persisting them to the database, even though OTF doesn't support them (yet).

This also means OTF supports the `tfe` provider's `tfe_team` resource (unsupported fields aside).