### PR TITLE
chore: Bump default terraform version to v1.5.2

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -21,7 +21,7 @@ const (
 	DefaultFileTriggersEnabled = true
 
 	MinTerraformVersion     = "1.2.0"
-	DefaultTerraformVersion = "1.4.6"
+	DefaultTerraformVersion = "1.5.2"
 )
 
 var ErrNoVCSConnection = errors.New("workspace is not connected to a vcs repo")


### PR DESCRIPTION
The following bumps the default version to v1.5.2.