### PR TITLE
feat!: adding team member creates user if they don't exist

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -2,6 +2,22 @@
 
 The authorization model largely follows that of Terraform Cloud/Enterprise. An organization comprises a number of teams. A user is a member of one or more teams. Teams are assigned permissions permitting access to various functionality. Team permissions can be assigned at two levels: on organizations and on individual workspaces.
 
+## Users
+
+A user is created via one of several methods:
+
+* A user successfully logs into the site for the first time via an identity provider.
+* A site admin creates a user via the CLI/API.
+* If a user is added to a team and no user with the specified username exists.
+
+A user without team membership has no permissions other than the ability to create organizations (which can be [disabled](../config/flags/#-restrict-org-creation)).
+
+## Teams
+
+Only [owners](#owners) can create teams and manage team membership. To add a user to a team, a username is specified. If no user exists with that username then the user is automatically created.
+
+A new team possesses no [permissions](#permissions) until they are assigned.
+
 ## Owners
 
 Every organization has an `owners` team. The user that creates an organization becomes its owner. The owners team must have at least one member and it cannot be deleted.

--- a/internal/auth/team_web.go
+++ b/internal/auth/team_web.go
@@ -129,13 +129,12 @@ func (h *webHandlers) getTeam(w http.ResponseWriter, r *http.Request) {
 		DeleteTeamAction:           rbac.DeleteTeamAction,
 		CanAddMember:               user.CanAccessOrganization(rbac.AddTeamMembershipAction, team.Organization),
 		AddMemberDropdown: html.DropdownUI{
-			Name:         "username",
-			Available:    nonMemberUsernames,
-			Existing:     usernames,
-			AddAction:    paths.AddMemberTeam(team.ID),
-			CreateAction: paths.CreateUser(team.Organization),
-			Placeholder:  "Add user",
-			Width:        "wide",
+			Name:        "username",
+			Available:   nonMemberUsernames,
+			Existing:    usernames,
+			Action:      paths.AddMemberTeam(team.ID),
+			Placeholder: "Add user",
+			Width:       "wide",
 		},
 	})
 }
@@ -210,8 +209,8 @@ func (h *webHandlers) deleteTeam(w http.ResponseWriter, r *http.Request) {
 
 func (h *webHandlers) addTeamMember(w http.ResponseWriter, r *http.Request) {
 	var params struct {
-		TeamID   string `schema:"team_id,required"`
-		Username string `schema:"username,required"`
+		TeamID   string  `schema:"team_id,required"`
+		Username *string `schema:"username,required"`
 	}
 	if err := decode.All(&params, r); err != nil {
 		h.Error(w, err.Error(), http.StatusUnprocessableEntity)
@@ -220,14 +219,14 @@ func (h *webHandlers) addTeamMember(w http.ResponseWriter, r *http.Request) {
 
 	err := h.svc.AddTeamMembership(r.Context(), TeamMembershipOptions{
 		TeamID:    params.TeamID,
-		Usernames: []string{params.Username},
+		Usernames: []string{*params.Username},
 	})
 	if err != nil {
 		h.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	html.FlashSuccess(w, "added team member: "+params.Username)
+	html.FlashSuccess(w, "added team member: "+*params.Username)
 	http.Redirect(w, r, paths.Team(params.TeamID), http.StatusFound)
 }
 

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -110,10 +110,11 @@ func (u *User) IsSiteAdmin() bool {
 }
 
 func (u *User) CanAccessSite(action rbac.Action) bool {
-	// User can list users across a site if they are an owner of at least one
-	// org (this is expressely so that they can browse users before adding a
-	// user to a team).
-	if action == rbac.ListUsersAction {
+	switch action {
+	case rbac.CreateUserAction:
+		// A user can create a user account only if they are an owner of at least
+		// one organization. This permits an owner to create a user before adding
+		// them to a team.
 		for _, team := range u.Teams {
 			if team.IsOwners() {
 				return true

--- a/internal/http/html/html.go
+++ b/internal/http/html/html.go
@@ -24,10 +24,8 @@ type (
 		Existing []string
 		// Available values to show in the dropdown
 		Available []string
-		// AddAction is the form action URL for adding an existing resource
-		AddAction string
-		// CreateAction is the form action URL for creating a new resource
-		CreateAction string
+		// Action is the form action URL
+		Action string
 		// Placeholder to show in the input element.
 		Placeholder string
 		// Width: "narrow" or "wide"

--- a/internal/http/html/html.go
+++ b/internal/http/html/html.go
@@ -15,6 +15,26 @@ const (
 	pathCookie = "path"
 )
 
+type (
+	// DropdownUI populates a search/dropdown UI component.
+	DropdownUI struct {
+		// Name to send along with value in the POST form
+		Name string
+		// Existing values to NOT show in the dropdown
+		Existing []string
+		// Available values to show in the dropdown
+		Available []string
+		// AddAction is the form action URL for adding an existing resource
+		AddAction string
+		// CreateAction is the form action URL for creating a new resource
+		CreateAction string
+		// Placeholder to show in the input element.
+		Placeholder string
+		// Width: "narrow" or "wide"
+		Width string
+	}
+)
+
 func MarkdownToHTML(md []byte) template.HTML {
 	return template.HTML(string(markdown.ToHTML(md, nil, nil)))
 }

--- a/internal/http/html/static/css/output.css
+++ b/internal/http/html/static/css/output.css
@@ -862,10 +862,6 @@ select {
   max-width: 56rem;
 }
 
-.flex-grow {
-  flex-grow: 1;
-}
-
 .grow {
   flex-grow: 1;
 }
@@ -928,6 +924,10 @@ select {
 
 .gap-6 {
   gap: 1.5rem;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
 }
 
 .whitespace-pre-wrap {

--- a/internal/http/html/static/templates/content/team_get.tmpl
+++ b/internal/http/html/static/templates/content/team_get.tmpl
@@ -8,7 +8,6 @@
 {{ define "content" }}
   {{ $canDelete := .CurrentUser.CanAccessOrganization .DeleteTeamAction .Organization }}
   {{ $canSetPermission := .CurrentUser.IsOwner .Organization }}
-  {{ $canAddMember := .CurrentUser.CanAccessOrganization .AddTeamMembershipAction .Organization }}
   {{ $canRemoveMember := .CurrentUser.CanAccessOrganization .RemoveTeamMembershipAction .Organization }}
   <h3 class="font-semibold my-2 text-lg">Permissions</h3>
   <form class="flex flex-col gap-5" action="{{ updateTeamPath .Team.ID }}" method="POST">
@@ -60,17 +59,9 @@
   </form>
   <hr class="my-4">
   <h3 class="font-semibold my-2 text-lg">Members</h3>
-  <form action="{{ addMemberTeamPath .Team.ID }}" method="POST">
-    <select id="select-add-member" name="username" {{ disabled (not $canAddMember) }}>
-      <option value="">-- select user --</option>
-      {{ range .NonMembers }}
-        <option value="{{ .Username }}">{{ .Username }}</option>
-      {{ else }}
-        <option value="">No users found</option>
-      {{ end }}
-    </select>
-    <button class="btn" {{ insufficient $canAddMember }}>Add member</button>
-  </form>
+  {{ if .CanAddMember }}
+    {{ template "search-dropdown" .AddMemberDropdown }}
+  {{ end }}
   <div id="content-list">
     {{ range .Members }}
       <div id="item-user-{{ .Username }}" class="widget">

--- a/internal/http/html/static/templates/content/team_get.tmpl
+++ b/internal/http/html/static/templates/content/team_get.tmpl
@@ -6,9 +6,6 @@
 {{ .Team.Name }}{{ end }}
 
 {{ define "content" }}
-  {{ $canDelete := .CurrentUser.CanAccessOrganization .DeleteTeamAction .Organization }}
-  {{ $canSetPermission := .CurrentUser.IsOwner .Organization }}
-  {{ $canRemoveMember := .CurrentUser.CanAccessOrganization .RemoveTeamMembershipAction .Organization }}
   <h3 class="font-semibold my-2 text-lg">Permissions</h3>
   <form class="flex flex-col gap-5" action="{{ updateTeamPath .Team.ID }}" method="POST">
     <div class="form-checkbox">
@@ -18,7 +15,7 @@
         id="manage_workspaces"
         value="true"
         {{ if or .Team.OrganizationAccess.ManageWorkspaces .Team.IsOwners }}checked{{ end }}
-        {{ if or (not $canSetPermission) .Team.IsOwners }}disabled{{ end }}
+        {{ if or (not .IsOwner) .Team.IsOwners }}disabled{{ end }}
       >
       <label for="manage_workspaces">Manage Workspaces</label>
       <span>Allows members to create and administrate all workspaces within the organization.</span>
@@ -30,7 +27,7 @@
         id="manage_vcs"
         value="true"
         {{ if or .Team.OrganizationAccess.ManageVCS .Team.IsOwners }}checked{{ end }}
-        {{ if or (not $canSetPermission) .Team.IsOwners }}disabled{{ end }}
+        {{ if or (not .IsOwner) .Team.IsOwners }}disabled{{ end }}
       >
       <label for="manage_vcs">Manage VCS Settings</label>
       <span>Allows members to manage the set of VCS providers available within the organization.</span>
@@ -42,7 +39,7 @@
         id="manage_modules"
         value="true"
         {{ if or .Team.OrganizationAccess.ManageModules .Team.IsOwners }}checked{{ end }}
-        {{ if or (not $canSetPermission) .Team.IsOwners }}disabled{{ end }}
+        {{ if or (not .IsOwner) .Team.IsOwners }}disabled{{ end }}
       >
       <label for="manage_modules">Manage Modules</label>
       <span for="manage_modules">Allows members to publish and delete modules within the organization.</span>
@@ -52,7 +49,7 @@
         {{ if .Team.IsOwners }}
           title="cannot edit permissions of owners team" disabled
         {{ else }}
-          {{ insufficient $canSetPermission }}
+          {{ insufficient .IsOwner }}
         {{ end }}
       >Save changes</button>
     </div>
@@ -72,7 +69,7 @@
           {{ template "identifier" . }}
           <form action="{{ removeMemberTeamPath $.Team.ID }}" method="POST">
             <input type="hidden" name="username" id="delete-username" value="{{ .Username }}">
-            <button id="remove-member-button" class="btn-danger" {{ insufficient $canRemoveMember }}>
+            <button id="remove-member-button" class="btn-danger" {{ insufficient $.CanRemoveMember }}>
               Remove member
             </button>
           </form>
@@ -90,7 +87,7 @@
       {{ if .Team.IsOwners }}
         title="the owners team cannot be deleted" disabled
       {{ else }}
-        {{ insufficient $canDelete }}
+        {{ insufficient .CanDelete }}
       {{ end }}
       onclick="return confirm('Are you sure you want to delete?')">Delete team</button>
     <input type="hidden" name="id" value="{{ .Team.ID }}">

--- a/internal/http/html/static/templates/content/workspace_get.tmpl
+++ b/internal/http/html/static/templates/content/workspace_get.tmpl
@@ -1,9 +1,5 @@
 {{ template "layout" . }}
 
-{{ define "pre-content" }}
-  <script src="{{ addHash "/static/js/search_dropdown.js" }}"></script>
-{{ end }}
-
 {{ define "content-header-title" }}
   <a href="{{ workspacesPath .Organization }}">workspaces</a> / {{ .Workspace.Name }}
 {{ end }}
@@ -70,7 +66,7 @@
           {{ end }}
         </div>
         {{ if .CanAddTags }}
-          {{ template "search-dropdown" . }}
+          {{ template "search-dropdown" .TagsDropdown }}
         {{ end }}
       </div>
     </div>

--- a/internal/http/html/static/templates/partials/search_dropdown.tmpl
+++ b/internal/http/html/static/templates/partials/search_dropdown.tmpl
@@ -5,7 +5,7 @@
   <div
       x-data="search_dropdown({{ toJson .Existing }}, {{ toJson .Available }})"
       x-ref="searchdrop"
-      @keydown.escape.prevent.stop="close($refs.button)"
+      @keydown.escape.prevent.stop="close($refs.input-search)"
       @focusin.window="! $refs.searchdrop.contains($event.target) && close()"
       @click.outside="close()"
       x-id="['dropdown-button']"
@@ -16,7 +16,7 @@
         @focusin="open = true"
         x-model="search"
         type="text"
-        x-ref="button"
+        x-ref="input-search"
         @click="open = true"
         :aria-expanded="open"
         :aria-controls="$id('dropdown-button')"

--- a/internal/http/html/static/templates/partials/search_dropdown.tmpl
+++ b/internal/http/html/static/templates/partials/search_dropdown.tmpl
@@ -1,8 +1,9 @@
 {{ define "search-dropdown" }}
-  <form id="search-dropdown" action="{{ createTagWorkspacePath .Workspace.ID }}" method="POST">
-  </form>
+  {{ $width := dict "narrow" "w-40" "wide" "w-80" }}
+  <script src="{{ addHash "/static/js/search_dropdown.js" }}"></script>
+  <form id="search-dropdown" action="{{ .Action }}" method="POST"></form>
   <div
-      x-data="search_dropdown({{ toJson .Workspace.Tags }}, {{ toJson .UnassignedTags }})"
+      x-data="search_dropdown({{ toJson .Existing }}, {{ toJson .Available }})"
       x-ref="searchdrop"
       @keydown.escape.prevent.stop="close($refs.button)"
       @focusin.window="! $refs.searchdrop.contains($event.target) && close()"
@@ -18,10 +19,10 @@
         @click="open = true"
         :aria-expanded="open"
         :aria-controls="$id('dropdown-button')"
-        class="flex items-center w-40 gap-2 bg-white px-2 py-1 border"
-        placeholder="Add tags"
+        class="flex items-center {{ $width }} gap-2 bg-white px-2 py-1 border"
+        placeholder="{{ .Placeholder }}"
         form="search-dropdown"
-        name="tag_name"
+        name="{{ .Name }}"
         >
     <div
         x-ref="panel"
@@ -29,15 +30,15 @@
         x-transition.origin.top.left
         :id="$id('dropdown-button')"
         x-cloak
-        class="absolute w-40 mt-1 bg-white border"
+        class="absolute {{ $width }} mt-1 bg-white border border-black overflow-x-auto"
         >
         <div class="sticky bottom-0 flex flex-col">
-          <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="tag_name" :value="search" for="create-tag" x-show="isNew">
+          <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="{{ .Name }}" :value="search" x-show="isNew">
             Create:<span class="" x-text="search"></span>
           </button>
 
           <template x-for="item in filterAvailable" :key="item">
-            <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="tag_name" :value="item" for="create-tag" x-text="item"></button>
+            <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="{{ .Name }}" :value="item" x-text="item"></button>
           </template>
         </div>
     </div>

--- a/internal/http/html/static/templates/partials/search_dropdown.tmpl
+++ b/internal/http/html/static/templates/partials/search_dropdown.tmpl
@@ -11,6 +11,7 @@
       x-id="['dropdown-button']"
       class="relative"
       >
+    <input type="hidden" name="{{ .Name }}" :value="search" form="search-dropdown">
     <input
         @focusin="open = true"
         x-model="search"
@@ -19,10 +20,9 @@
         @click="open = true"
         :aria-expanded="open"
         :aria-controls="$id('dropdown-button')"
-        class="flex items-center {{ $width }} gap-2 bg-white px-2 py-1 border"
+        class="flex items-center {{ get $width .Width }} gap-2 bg-white px-2 py-1 border"
         placeholder="{{ .Placeholder }}"
         form="search-dropdown"
-        name="{{ .Name }}"
         >
     <div
         x-ref="panel"
@@ -30,15 +30,15 @@
         x-transition.origin.top.left
         :id="$id('dropdown-button')"
         x-cloak
-        class="absolute {{ $width }} mt-1 bg-white border border-black overflow-x-auto"
+        class="absolute {{ get $width .Width }} mt-1 bg-white border border-black overflow-x-auto"
         >
         <div class="sticky bottom-0 flex flex-col">
-          <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="{{ .Name }}" :value="search" x-show="isNew">
+          <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" x-show="isNew">
             Create:<span class="" x-text="search"></span>
           </button>
 
           <template x-for="item in filterAvailable" :key="item">
-            <button form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" name="{{ .Name }}" :value="item" x-text="item"></button>
+            <button @click="search = item" form="search-dropdown" class="text-left focus:bg-gray-200 hover:bg-gray-200 py-1 px-2" x-text="item"></button>
           </template>
         </div>
     </div>

--- a/internal/integration/tag_e2e_test.go
+++ b/internal/integration/tag_e2e_test.go
@@ -79,9 +79,9 @@ resource "null_resource" "tags_e2e" {}
 		screenshot(t),
 		matchText(t, "//div[@role='alert']", "removed tag: bar"),
 		// add new tag
-		chromedp.Focus(`//input[@form='search-dropdown']`),
+		chromedp.Focus(`//input[@x-ref='input-search']`),
 		input.InsertText("baz"),
-		chromedp.Submit(`//input[@form='search-dropdown']`),
+		chromedp.Submit(`//input[@x-ref='input-search']`),
 		screenshot(t),
 		matchText(t, "//div[@role='alert']", "created tag: baz"),
 		// go to workspace listing

--- a/internal/integration/team_ui_test.go
+++ b/internal/integration/team_ui_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/chromedp/cdproto/input"
 	"github.com/chromedp/chromedp"
 )
 
@@ -27,10 +28,11 @@ func TestIntegration_TeamUI(t *testing.T) {
 			chromedp.Click(`//div[@class='content-list']//a[text()='owners']`),
 			screenshot(t, "owners_team_page"),
 			// select newbie as new team member
-			chromedp.SetValue(`//select[@id="select-add-member"]`, newbie.Username),
+			chromedp.Focus(`//input[@x-ref='input-search']`),
+			input.InsertText(newbie.Username),
 			screenshot(t),
 			// submit
-			chromedp.Click(`//button[text()='Add member']`),
+			chromedp.Submit(`//input[@x-ref='input-search']`),
 			screenshot(t),
 			// confirm newbie added
 			matchText(t, "//div[@role='alert']", "added team member: "+newbie.Username),

--- a/internal/rbac/role.go
+++ b/internal/rbac/role.go
@@ -15,6 +15,7 @@ var (
 			GetModuleAction:        true,
 			GetTeamAction:          true,
 			ListTeamsAction:        true,
+			GetUserAction:          true,
 			ListUsersAction:        true,
 			ListTagsAction:         true,
 			ListVCSProvidersAction: true,

--- a/internal/workspace/web.go
+++ b/internal/workspace/web.go
@@ -235,14 +235,21 @@ func (h *webHandlers) getWorkspace(w http.ResponseWriter, r *http.Request) {
 		CanAddTags     bool
 		CanRemoveTags  bool
 		UnassignedTags []string
+		TagsDropdown   html.DropdownUI
 	}{
-		WorkspacePage:  NewPage(r, ws.ID, ws),
-		LockButton:     lockButtonHelper(ws, policy, user),
-		VCSProvider:    provider,
-		CanApply:       user.CanAccessWorkspace(rbac.ApplyRunAction, policy),
-		CanAddTags:     user.CanAccessWorkspace(rbac.AddTagsAction, policy),
-		CanRemoveTags:  user.CanAccessWorkspace(rbac.RemoveTagsAction, policy),
-		UnassignedTags: internal.DiffStrings(getTagNames(), ws.Tags),
+		WorkspacePage: NewPage(r, ws.ID, ws),
+		LockButton:    lockButtonHelper(ws, policy, user),
+		VCSProvider:   provider,
+		CanApply:      user.CanAccessWorkspace(rbac.ApplyRunAction, policy),
+		CanAddTags:    user.CanAccessWorkspace(rbac.AddTagsAction, policy),
+		CanRemoveTags: user.CanAccessWorkspace(rbac.RemoveTagsAction, policy),
+		TagsDropdown: html.DropdownUI{
+			Name:        "tag_name",
+			Available:   internal.DiffStrings(getTagNames(), ws.Tags),
+			Existing:    ws.Tags,
+			AddAction:   paths.CreateTagWorkspace(ws.ID),
+			Placeholder: "Add tags",
+		},
 	})
 }
 

--- a/internal/workspace/web.go
+++ b/internal/workspace/web.go
@@ -247,8 +247,9 @@ func (h *webHandlers) getWorkspace(w http.ResponseWriter, r *http.Request) {
 			Name:        "tag_name",
 			Available:   internal.DiffStrings(getTagNames(), ws.Tags),
 			Existing:    ws.Tags,
-			AddAction:   paths.CreateTagWorkspace(ws.ID),
+			Action:      paths.CreateTagWorkspace(ws.ID),
 			Placeholder: "Add tags",
+			Width:       "narrow",
 		},
 	})
 }


### PR DESCRIPTION
This PR changes the behaviour of the add team member functionality, both via the UI and the API: when adding a user to a team, if the user does not exist the user is created.

This is a deviation from TFC's behaviour. But then OTF already differs quite a bit from TFC when it comes to users: in OTF, users are not "invited" and are instead created the first time they login. There is no email functionality because that would add a further dependency (a mail relay).