### PR TITLE
fix: handle run-events request from terraform cloud backend

### DIFF
--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -46,6 +46,9 @@ func (a *api) addRunHandlers(r *mux.Router) {
 
 	// Apply routes
 	r.HandleFunc("/applies/{apply_id}", a.getApply).Methods("GET")
+
+	// Run events routes
+	r.HandleFunc("/runs/{id}/run-events", a.listRunEvents).Methods("GET")
 }
 
 func (a *api) createRun(w http.ResponseWriter, r *http.Request) {
@@ -420,4 +423,11 @@ func (a *api) watchRun(w http.ResponseWriter, r *http.Request) {
 		pubsub.WriteSSEEvent(w, b, event.Type, true)
 		flusher.Flush()
 	}
+}
+
+// OTF doesn't implement run events but as of terraform v1.5, the cloud backend
+// makes a call to this endpoint. OTF therefore stubs this endpoint and sends an
+// empty response, to avoid sending a 404 response and triggering an error.
+func (a *api) listRunEvents(w http.ResponseWriter, r *http.Request) {
+	a.writeResponse(w, r, []*types.RunEvent{})
 }

--- a/internal/api/types/run_event.go
+++ b/internal/api/types/run_event.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import "time"
+
+// RunEventList represents a list of run events.
+type RunEventList struct {
+	// Pagination is not supported by the API
+	*Pagination
+	Items []*RunEvent
+}
+
+// RunEvent represents a Terraform Enterprise run event.
+type RunEvent struct {
+	ID          string    `jsonapi:"primary,run-events"`
+	Action      string    `jsonapi:"attr,action"`
+	CreatedAt   time.Time `jsonapi:"attr,created-at,iso8601"`
+	Description string    `jsonapi:"attr,description"`
+
+	// Relations - Note that `target` is not supported yet
+	Actor *User `jsonapi:"relation,actor"`
+	// Comment *Comment `jsonapi:"relation,comment"`
+}


### PR DESCRIPTION
`terraform plan|apply` as of v1.5 sends a request to `/api/v2/runs/<run_id>/run-events` if using the `cloud` backend. OTF did not handle this request and hence terraform would error with `resource not found`.

This PR stubs this endpoint, returning an empty response, which works around the issue.

(Run events would usually be warnings about various policy issues OTF doesn't implement anyway).