### PR TITLE
chore: remove redundant CreateRun magic string

### DIFF
--- a/internal/http/html/static/templates/content/workspace_get.tmpl
+++ b/internal/http/html/static/templates/content/workspace_get.tmpl
@@ -31,7 +31,6 @@
         <div class="actions-container">
           <h3 class="font-semibold mb-2">Actions</h3>
           <form id="workspace-start-run-form" action="{{ startRunWorkspacePath .Workspace.ID }}" method="POST">
-            <input type="hidden" name="connected" value="{{ ne .Workspace.Connection nil }}">
             <select name="operation" id="start-run-operation" onchange="this.form.submit()">
               <option value="" selected>-- start run --</option>
               <option value="plan-only">plan only</option>

--- a/internal/integration/run_test.go
+++ b/internal/integration/run_test.go
@@ -27,34 +27,6 @@ func TestRun(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// test the "magic string" behaviour specific to OTF: if
-	// run.PullVCSMagicString is specified for the config version ID then the
-	// config is pulled from the workspace's connected repo.
-	t.Run("magic string - create run using config from repo", func(t *testing.T) {
-		// setup daemon along with fake github repo
-		repo := cloud.NewTestRepo()
-		daemon, _, ctx := setup(t, nil,
-			github.WithRepo(repo),
-			github.WithArchive(testutils.ReadFile(t, "../testdata/github.tar.gz")),
-		)
-		org := daemon.createOrganization(t, ctx)
-		vcsProvider := daemon.createVCSProvider(t, ctx, org)
-		ws, err := daemon.CreateWorkspace(ctx, workspace.CreateOptions{
-			Name:         internal.String("connected-workspace"),
-			Organization: internal.String(org.Name),
-			ConnectOptions: &workspace.ConnectOptions{
-				RepoPath:      &repo,
-				VCSProviderID: &vcsProvider.ID,
-			},
-		})
-		require.NoError(t, err)
-
-		_, err = daemon.CreateRun(ctx, ws.ID, run.RunCreateOptions{
-			ConfigurationVersionID: internal.String(run.PullVCSMagicString),
-		})
-		require.NoError(t, err)
-	})
-
 	t.Run("create run using config from repo", func(t *testing.T) {
 		// setup daemon along with fake github repo
 		repo := cloud.NewTestRepo()

--- a/internal/run/factory_test.go
+++ b/internal/run/factory_test.go
@@ -82,24 +82,6 @@ func TestFactory(t *testing.T) {
 		assert.True(t, got.AutoApply)
 	})
 
-	t.Run("magic string - pull from vcs", func(t *testing.T) {
-		f := newTestFactory(
-			&workspace.Workspace{
-				Connection: &workspace.Connection{},
-			},
-			&configversion.ConfigurationVersion{},
-		)
-
-		got, err := f.NewRun(ctx, "", RunCreateOptions{
-			ConfigurationVersionID: internal.String(PullVCSMagicString),
-		})
-		require.NoError(t, err)
-
-		// fake config version service sets the config version ID to "created"
-		// if it was newly created
-		assert.Equal(t, "created", got.ConfigurationVersionID)
-	})
-
 	t.Run("pull from vcs", func(t *testing.T) {
 		f := newTestFactory(
 			&workspace.Workspace{
@@ -114,18 +96,6 @@ func TestFactory(t *testing.T) {
 		// fake config version service sets the config version ID to "created"
 		// if it was newly created
 		assert.Equal(t, "created", got.ConfigurationVersionID)
-	})
-
-	t.Run("pull from vcs workspace not connected error", func(t *testing.T) {
-		f := newTestFactory(
-			&workspace.Workspace{}, // workspace with no connection
-			&configversion.ConfigurationVersion{},
-		)
-
-		_, err := f.NewRun(ctx, "", RunCreateOptions{
-			ConfigurationVersionID: internal.String(PullVCSMagicString),
-		})
-		require.Equal(t, err, workspace.ErrNoVCSConnection)
 	})
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -18,12 +18,6 @@ const (
 	PlanFormatBinary = "bin"  // plan file in binary format
 	PlanFormatJSON   = "json" // plan file in json format
 
-	// When specified in place of a configuration version ID passed to
-	// RunCreateOptions this magic string instructs the run factory to
-	// automatically create a configuration version from the workspace connected
-	// vcs repo.
-	PullVCSMagicString = "__pull_vcs__"
-
 	PlanOnlyOperation     Operation = "plan-only"
 	PlanAndApplyOperation Operation = "plan-and-apply"
 	DestroyAllOperation   Operation = "destroy-all"
@@ -89,14 +83,8 @@ type (
 		RefreshOnly *bool
 		Message     *string
 		// Specifies the configuration version to use for this run. If the
-		// configuration version object is omitted, the run will be created using the
+		// configuration version ID is nil, the run will be created using the
 		// workspace's latest configuration version.
-		//
-		// Alternatively, if PullVCSMagicString is specified, and the workspace
-		// is connected to a vcs repo, then a configuration version is
-		// automatically created from the vcs repo and the run uses that
-		// configuration version. If the workspace is not connected to a
-		// workspace then an error is returned.
 		ConfigurationVersionID *string
 		TargetAddrs            []string
 		ReplaceAddrs           []string

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -26,7 +26,6 @@ const (
 )
 
 var (
-	ErrNoVCSConnection                 = errors.New("workspace is not connected to a vcs repo")
 	ErrTagsRegexAndTriggerPatterns     = errors.New("cannot specify both tags-regex and trigger-patterns")
 	ErrTagsRegexAndAlwaysTrigger       = errors.New("cannot specify both tags-regex and always-trigger")
 	ErrTriggerPatternsAndAlwaysTrigger = errors.New("cannot specify both trigger-patterns and always-trigger")


### PR DESCRIPTION
@fsaintjacques A heads up - I recall removing the magic string behaviour from your software, so I'm pretty sure this is now safe to remove from OTF.

(If you recall, when creating a run, we wanted the run to automatically fetch the config from the git repo, so we introduced a magic string to invoke this behaviour. But then I realised you could simply leave out the configuration version ID from CreateRun and that invokes the same behaviour).