### PR TITLE
Make workspace page title use Name, not ID

### DIFF
--- a/internal/workspace/web.go
+++ b/internal/workspace/web.go
@@ -269,7 +269,7 @@ func (h *webHandlers) getWorkspace(w http.ResponseWriter, r *http.Request) {
 		UnassignedTags     []string
 		TagsDropdown       html.DropdownUI
 	}{
-		WorkspacePage:      NewPage(r, ws.ID, ws),
+		WorkspacePage:      NewPage(r, ws.Name, ws),
 		LockButton:         lockButtonHelper(ws, policy, user),
 		VCSProvider:        provider,
 		CanApply:           user.CanAccessWorkspace(rbac.ApplyRunAction, policy),


### PR DESCRIPTION
Closes #579

Use the `.Name` of the workspace as the page `<title>` instead of the `ID`, for friendly viewing.

The `.ID` is still available in both the URL and on the page of the workspace
