### PR TITLE
fix: restart spooler when broker terminates subscription

### DIFF
--- a/internal/agent/spooler.go
+++ b/internal/agent/spooler.go
@@ -57,14 +57,14 @@ func newSpooler(app client, logger logr.Logger, cfg Config) *spoolerDaemon {
 	}
 }
 
-// start starts the spooler
+// start the spooler
 func (s *spoolerDaemon) start(ctx context.Context) error {
 	op := func() error {
 		return s.reinitialize(ctx)
 	}
 	policy := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
 	return backoff.RetryNotify(op, policy, func(err error, next time.Duration) {
-		s.Error(fmt.Errorf("%w: reconnecting in %s", err, next), "stream update")
+		s.Error(err, "restarting spooler", "backoff", next)
 	})
 }
 
@@ -114,7 +114,7 @@ func (s *spoolerDaemon) reinitialize(ctx context.Context) error {
 			return err
 		}
 	}
-	return nil
+	return pubsub.ErrSubscriptionTerminated
 }
 
 func (s *spoolerDaemon) handleEvent(ev pubsub.Event) error {

--- a/internal/agent/spooler_test.go
+++ b/internal/agent/spooler_test.go
@@ -44,7 +44,7 @@ func TestSpooler(t *testing.T) {
 	assert.Equal(t, cancelation{Run: run4, Forceful: false}, <-spooler.getCancelation())
 	assert.Equal(t, cancelation{Run: run5, Forceful: true}, <-spooler.getCancelation())
 	cancel()
-	assert.NoError(t, <-errch)
+	assert.Equal(t, pubsub.ErrSubscriptionTerminated, <-errch)
 }
 
 func TestSpooler_handleEvent(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -371,24 +371,21 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 
 	subsystems := []*Subsystem{
 		{
-			Name:           "broker",
-			BackoffRestart: true,
-			Logger:         d.Logger,
-			System:         d.Broker,
+			Name:   "broker",
+			Logger: d.Logger,
+			System: d.Broker,
 		},
 		{
-			Name:           "proxy",
-			BackoffRestart: true,
-			Logger:         d.Logger,
-			System:         d.LogsService,
+			Name:   "proxy",
+			Logger: d.Logger,
+			System: d.LogsService,
 		},
 		{
-			Name:           "reporter",
-			BackoffRestart: true,
-			Logger:         d.Logger,
-			Exclusive:      true,
-			DB:             d.DB,
-			LockID:         internal.Int64(run.ReporterLockID),
+			Name:      "reporter",
+			Logger:    d.Logger,
+			Exclusive: true,
+			DB:        d.DB,
+			LockID:    internal.Int64(run.ReporterLockID),
 			System: &run.Reporter{
 				Logger:                      d.Logger.WithValues("component", "reporter"),
 				VCSProviderService:          d.VCSProviderService,
@@ -399,9 +396,8 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 			},
 		},
 		{
-			Name:           "webhook purger",
-			BackoffRestart: true,
-			Logger:         d.Logger,
+			Name:   "webhook purger",
+			Logger: d.Logger,
 			System: &repo.Purger{
 				Logger:     d.Logger.WithValues("component", "purger"),
 				Subscriber: d.Broker,
@@ -410,12 +406,11 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 			},
 		},
 		{
-			Name:           "notifier",
-			BackoffRestart: true,
-			Logger:         d.Logger,
-			Exclusive:      true,
-			DB:             d.DB,
-			LockID:         internal.Int64(notifications.LockID),
+			Name:      "notifier",
+			Logger:    d.Logger,
+			Exclusive: true,
+			DB:        d.DB,
+			LockID:    internal.Int64(notifications.LockID),
 			System: notifications.NewNotifier(notifications.NotifierOptions{
 				Logger:           d.Logger,
 				Subscriber:       d.Broker,
@@ -427,12 +422,11 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 	}
 	if !d.DisableScheduler {
 		subsystems = append(subsystems, &Subsystem{
-			Name:           "scheduler",
-			BackoffRestart: true,
-			Logger:         d.Logger,
-			Exclusive:      true,
-			DB:             d.DB,
-			LockID:         internal.Int64(scheduler.LockID),
+			Name:      "scheduler",
+			Logger:    d.Logger,
+			Exclusive: true,
+			DB:        d.DB,
+			LockID:    internal.Int64(scheduler.LockID),
 			System: scheduler.NewScheduler(scheduler.Options{
 				Logger:           d.Logger,
 				WorkspaceService: d.WorkspaceService,

--- a/internal/daemon/subsystem.go
+++ b/internal/daemon/subsystem.go
@@ -76,8 +76,7 @@ func (s *Subsystem) Start(ctx context.Context, g *errgroup.Group) error {
 		policy := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
 		g.Go(func() error {
 			return backoff.RetryNotify(op, policy, func(err error, next time.Duration) {
-				// re-open semaphore
-				s.Error(err, "restarting "+s.Name)
+				s.Error(err, "restarting subsystem", "name", s.Name, "backoff", next)
 			})
 		})
 	} else {

--- a/internal/daemon/subsystem_test.go
+++ b/internal/daemon/subsystem_test.go
@@ -15,21 +15,18 @@ func TestSubsystem(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		backoff   bool
 		exclusive bool
 	}{
-		{"default", false, false},
-		{"backoff", true, false},
-		{"backoff and wait and lock", true, true},
+		{"backoff", false},
+		{"backoff and wait and lock", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sub := &Subsystem{
-				Name:           tt.name,
-				System:         &fakeStartable{},
-				Logger:         logr.Discard(),
-				BackoffRestart: tt.backoff,
-				Exclusive:      tt.exclusive,
+				Name:      tt.name,
+				System:    &fakeStartable{},
+				Logger:    logr.Discard(),
+				Exclusive: tt.exclusive,
 			}
 			if tt.exclusive {
 				sub.DB = &fakeWaitAndLock{}


### PR DESCRIPTION
Fixes #577 (again). The original fix, #593, left out the agent spooler system, which is responsible for relaying run events to the agent. So when its subscription was terminated, it didn't restart itself.

This PR changes that: the spooler will now restart itself whenever its subscription is terminated.