### PR TITLE
fix: fixed bug where proxy was ignored

### DIFF
--- a/internal/agent/terraform_downloader_test.go
+++ b/internal/agent/terraform_downloader_test.go
@@ -3,13 +3,13 @@ package agent
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
 
+	otfhttp "github.com/leg100/otf/internal/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,10 +28,7 @@ func TestDownloader(t *testing.T) {
 	dl := NewDownloader(pathFinder)
 	dl.host = u.Host
 	dl.client = &http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
+		Transport: otfhttp.DefaultTransport(true),
 	}
 
 	buf := new(bytes.Buffer)

--- a/internal/agent/terraform_downloader_test.go
+++ b/internal/agent/terraform_downloader_test.go
@@ -29,6 +29,7 @@ func TestDownloader(t *testing.T) {
 	dl.host = u.Host
 	dl.client = &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}

--- a/internal/authenticator/oidc_authenticator.go
+++ b/internal/authenticator/oidc_authenticator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/leg100/otf/internal"
@@ -54,6 +55,11 @@ func newOIDCAuthenticator(ctx context.Context, opts oidcAuthenticatorOptions) (*
 		Name:                opts.Name,
 		SkipTLSVerification: opts.SkipTLSVerification,
 	}
+
+	// here we are adding a timeout to prevent NewProvider from silently locking
+	// permanently in the case of networking issues.
+	ctx, cancelFn := context.WithTimeout(ctx, time.Second*10)
+	defer cancelFn()
 
 	// construct oidc provider, using our own http client, which lets us disable
 	// tls verification for testing purposes.

--- a/internal/authenticator/oidc_authenticator.go
+++ b/internal/authenticator/oidc_authenticator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/leg100/otf/internal"
@@ -55,11 +54,6 @@ func newOIDCAuthenticator(ctx context.Context, opts oidcAuthenticatorOptions) (*
 		Name:                opts.Name,
 		SkipTLSVerification: opts.SkipTLSVerification,
 	}
-
-	// here we are adding a timeout to prevent NewProvider from silently locking
-	// permanently in the case of networking issues.
-	ctx, cancelFn := context.WithTimeout(ctx, time.Second*10)
-	defer cancelFn()
 
 	// construct oidc provider, using our own http client, which lets us disable
 	// tls verification for testing purposes.

--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -2,8 +2,9 @@ package cloud
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
+
+	otfhttp "github.com/leg100/otf/internal/http"
 
 	"golang.org/x/oauth2"
 )
@@ -29,12 +30,7 @@ func (cfg *Config) NewClient(ctx context.Context, creds Credentials) (Client, er
 
 func (cfg *Config) HTTPClient() *http.Client {
 	return &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: cfg.SkipTLSVerification,
-			},
-		},
+		Transport: otfhttp.DefaultTransport(cfg.SkipTLSVerification),
 	}
 }
 

--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -30,6 +30,7 @@ func (cfg *Config) NewClient(ctx context.Context, creds Credentials) (Client, er
 func (cfg *Config) HTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: cfg.SkipTLSVerification,
 			},

--- a/internal/configversion/tfe_test.go
+++ b/internal/configversion/tfe_test.go
@@ -2,11 +2,12 @@ package configversion
 
 import (
 	"crypto/rand"
-	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	otfhttp "github.com/leg100/otf/internal/http"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -29,10 +30,7 @@ func TestUploadConfigurationVersion(t *testing.T) {
 
 	// setup client
 	client := http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
+		Transport: otfhttp.DefaultTransport(true),
 	}
 
 	// upload config smaller than MaxConfigSize

--- a/internal/configversion/tfe_test.go
+++ b/internal/configversion/tfe_test.go
@@ -30,6 +30,7 @@ func TestUploadConfigurationVersion(t *testing.T) {
 	// setup client
 	client := http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"context"
-	"crypto/tls"
+
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	otfhttp "github.com/leg100/otf/internal/http"
 
 	"github.com/google/go-github/v41/github"
 	"github.com/leg100/otf/internal"
@@ -32,10 +34,7 @@ func NewClient(ctx context.Context, cfg cloud.ClientOptions) (*Client, error) {
 	// Optionally skip TLS verification of github API
 	if cfg.SkipTLSVerification {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			Transport: otfhttp.DefaultTransport(true),
 		})
 	}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -33,6 +33,7 @@ func NewClient(ctx context.Context, cfg cloud.ClientOptions) (*Client, error) {
 	if cfg.SkipTLSVerification {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		})

--- a/internal/http/transport.go
+++ b/internal/http/transport.go
@@ -1,0 +1,16 @@
+package http
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func DefaultTransport(skipTLSVerification bool) http.RoundTripper {
+	dt := http.DefaultTransport
+	if skipTLSVerification {
+		dt.(*http.Transport).TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: skipTLSVerification,
+		}
+	}
+	return dt
+}

--- a/internal/http/transport.go
+++ b/internal/http/transport.go
@@ -5,12 +5,17 @@ import (
 	"net/http"
 )
 
+// DefaultTransport wraps the stdlib http.DefaultTransport, optionally disabling
+// TLS verification.
 func DefaultTransport(skipTLSVerification bool) http.RoundTripper {
-	dt := http.DefaultTransport
 	if skipTLSVerification {
-		dt.(*http.Transport).TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: skipTLSVerification,
+		// http.DefaultTransport is a pkg variable, so we need to clone it to
+		// avoid disabling TLS verification globally.
+		cloned := http.DefaultTransport.(*http.Transport).Clone()
+		cloned.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
 		}
+		return cloned
 	}
-	return dt
+	return http.DefaultTransport
 }

--- a/internal/run/client.go
+++ b/internal/run/client.go
@@ -3,9 +3,7 @@ package run
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
-	gohttp "net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -227,10 +225,7 @@ func newSSEClient(config http.Config, notifications chan pubsub.Event, opts Watc
 		"Authorization": "Bearer " + config.Token,
 	}
 	if config.Insecure {
-		client.Connection.Transport = &gohttp.Transport{
-			Proxy:           gohttp.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		client.Connection.Transport = http.DefaultTransport(true)
 	}
 	return client, nil
 }

--- a/internal/run/client.go
+++ b/internal/run/client.go
@@ -228,6 +228,7 @@ func newSSEClient(config http.Config, notifications chan pubsub.Event, opts Watc
 	}
 	if config.Insecure {
 		client.Connection.Transport = &gohttp.Transport{
+			Proxy:           gohttp.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	}


### PR DESCRIPTION
This PR does two main things, 

## http.Transport proxy
In areas where we manually construct an http.Transport unless we explicitly provide a Proxy field of http.ProxyFromEnvironment, we are explicitly configuring the http package to ignore the proxy environment variables. This means that otf ignores all proxy settings.

## oidc.NewProvider Timeout
Changes the oidc_authenticator to ensure that it throws an error after waiting for more than ten seconds to construct the oidc provider. This "fix" is intended to keep the tool silently waiting when the proxy settings are ommitted (or other network issues are blocking in the NewProvider func)