### PR TITLE
fix: prevent modules with no published versions from crashing otf

### DIFF
--- a/internal/module/web.go
+++ b/internal/module/web.go
@@ -113,7 +113,9 @@ func (h *webHandlers) get(w http.ResponseWriter, r *http.Request) {
 
 	switch module.Status {
 	case ModuleStatusSetupComplete:
-		readme = html.MarkdownToHTML(tfmod.readme)
+		if tfmod != nil {
+			readme = html.MarkdownToHTML(tfmod.readme)
+		}
 	}
 
 	h.Render("module_get.tmpl", w, struct {


### PR DESCRIPTION
This PR prevent modules with no published versions from triggering a nil panic.