### PR TITLE
Bump default terraform version to 1.6.2

### DIFF
--- a/internal/integration/github_app_test.go
+++ b/internal/integration/github_app_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -73,8 +74,10 @@ func TestIntegration_GithubAppNewUI(t *testing.T) {
 					var params struct {
 						Manifest manifest
 					}
-					err := json.NewDecoder(r.Body).Decode(&params)
+					body, err := io.ReadAll(r.Body)
 					require.NoError(t, err)
+					err = json.Unmarshal(body, &params)
+					require.NoError(t, err, "unmarshaling request body: %s", string(body))
 					assert.Equal(t, public, params.Manifest.Public)
 				})
 				stub := httptest.NewTLSServer(mux)

--- a/internal/integration/github_app_test.go
+++ b/internal/integration/github_app_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,11 +15,11 @@ import (
 	"github.com/leg100/otf/internal/auth"
 	"github.com/leg100/otf/internal/daemon"
 	"github.com/leg100/otf/internal/github"
+	"github.com/leg100/otf/internal/http/decode"
 	"github.com/leg100/otf/internal/run"
 	"github.com/leg100/otf/internal/testutils"
 	"github.com/leg100/otf/internal/vcsprovider"
 	"github.com/leg100/otf/internal/workspace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +31,9 @@ func TestIntegration_GithubAppNewUI(t *testing.T) {
 	// creating a github app requires site-admin role
 	ctx := internal.AddSubjectToContext(context.Background(), &auth.SiteAdmin)
 
+	// these tests submit the create github app form using different
+	// combinations of form fields, and then checking that a (stub) github server
+	// receives the completed form correctly.
 	tests := []struct {
 		name         string
 		public       bool   // whether to tick 'public' checkbox
@@ -68,17 +70,26 @@ func TestIntegration_GithubAppNewUI(t *testing.T) {
 			githubHostname := func(t *testing.T, path string, public bool) string {
 				mux := http.NewServeMux()
 				mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-					type manifest struct {
-						Public bool
-					}
-					var params struct {
-						Manifest manifest
-					}
-					body, err := io.ReadAll(r.Body)
+					// check that the manifest has been correctly submitted.
+					var (
+						manifest struct {
+							Public bool
+						}
+						params struct {
+							Manifest string `schema:"manifest,required"`
+						}
+					)
+					// first decode POST form manifest=<json>
+					err := decode.Form(&params, r)
 					require.NoError(t, err)
-					err = json.Unmarshal(body, &params)
-					require.NoError(t, err, "unmarshaling request body: %s", string(body))
-					assert.Equal(t, public, params.Manifest.Public)
+					// then unmarshal the json into a manifest
+					err = json.Unmarshal([]byte(params.Manifest), &manifest)
+					require.NoError(t, err)
+					require.Equal(t, public, manifest.Public)
+					w.Write([]byte(`<html><body>success</body></html>`))
+				})
+				mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+					t.Fatalf("form submitted to wrong path: %s", r.URL.Path)
 				})
 				stub := httptest.NewTLSServer(mux)
 				t.Cleanup(stub.Close)
@@ -108,6 +119,7 @@ func TestIntegration_GithubAppNewUI(t *testing.T) {
 				tasks = append(tasks, input.InsertText(tt.organization))
 			}
 			tasks = append(tasks, chromedp.Click(`//button[text()='Create']`))
+			tasks = append(tasks, chromedp.WaitVisible(`//body[text()='success']`))
 			browser.Run(t, ctx, tasks)
 		})
 	}

--- a/internal/integration/terraform_cli_cancel_test.go
+++ b/internal/integration/terraform_cli_cancel_test.go
@@ -49,6 +49,7 @@ data "http" "wait" {
 		[]string{tfpath, "-chdir=" + config, "plan", "-no-color"},
 		time.Minute,
 		expect.PartialMatch(true),
+		expect.Verbose(true),
 		expect.SetEnv(
 			append(sharedEnvs, internal.CredentialEnv(svc.Hostname(), token)),
 		),

--- a/internal/integration/terraform_cli_cancel_test.go
+++ b/internal/integration/terraform_cli_cancel_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
 	expect "github.com/google/goexpect"
 	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/run"
+	"github.com/leg100/otf/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,15 +24,14 @@ func TestIntegration_TerraformCLICancel(t *testing.T) {
 	svc, org, ctx := setup(t, nil)
 
 	// Canceling a run is not straight-forward, because to do so reliably the
-	// terraform plan should be interrupted precisely when it is in mid-flow,
+	// terraform apply should be interrupted precisely when it is in mid-flow,
 	// i.e. while it is planning. To achieve this, the test uses the 'http'
-	// data source, which contacts a test handler, which uses channels to
-	// co-ordinate sending the interrupt.
-	planning := make(chan struct{})
-	interrupted := make(chan struct{})
+	// data source, which contacts a test handler that never returns a response
+	// and so should cause terraform plan to hang. At this point the interrupt
+	// can be sent.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(planning)
-		<-interrupted
+		// never return
+		<-make(chan struct{})
 	}))
 
 	// create some config and run terraform init
@@ -43,13 +44,16 @@ data "http" "wait" {
 
 	tfpath := svc.downloadTerraform(t, ctx, nil)
 
-	// Invoke terraform plan
+	out, err := os.CreateTemp(t.TempDir(), "terraform-cli-cancel.out")
+	require.NoError(t, err)
+
+	// Invoke terraform apply
 	_, token := svc.createToken(t, ctx, nil)
 	e, tferr, err := expect.SpawnWithArgs(
-		[]string{tfpath, "-chdir=" + config, "plan", "-no-color"},
+		[]string{tfpath, "-chdir=" + config, "apply", "-no-color"},
 		time.Minute,
 		expect.PartialMatch(true),
-		expect.Verbose(true),
+		expect.Tee(out),
 		expect.SetEnv(
 			append(sharedEnvs, internal.CredentialEnv(svc.Hostname(), token)),
 		),
@@ -57,11 +61,12 @@ data "http" "wait" {
 	require.NoError(t, err)
 	defer e.Close()
 
-	// wait for terraform plan to call handler
-	<-planning
-	// send Ctrl-C now that terraform plan is in-flow.
+	// Wait for apply to start reading http data source that never returns
+	_, _, err = e.Expect(regexp.MustCompile(`data\.http\.wait: Reading\.\.\.`), time.Second*10)
+	require.NoError(t, err)
+
+	// Send Ctrl-C now that terraform apply is in-flow.
 	e.SendSignal(os.Interrupt)
-	close(interrupted)
 
 	// Confirm canceling run
 	e.ExpectBatch([]expect.Batcher{
@@ -70,7 +75,8 @@ data "http" "wait" {
 		&expect.BExp{R: "The remote operation was successfully cancelled."},
 	}, time.Minute)
 	// Terraform should return with exit code 0
-	require.NoError(t, <-tferr)
+	require.NoError(t, <-tferr, string(testutils.ReadFile(t, out.Name())))
+	t.Log(string(testutils.ReadFile(t, out.Name())))
 
 	runs, err := svc.ListRuns(ctx, run.ListOptions{Organization: &org.Name})
 	require.NoError(t, err)

--- a/internal/releases/releases.go
+++ b/internal/releases/releases.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultTerraformVersion = "1.6.2"
+	DefaultTerraformVersion = "1.6.0"
 	LatestVersionString     = "latest"
 )
 

--- a/internal/releases/releases.go
+++ b/internal/releases/releases.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultTerraformVersion = "1.5.2"
+	DefaultTerraformVersion = "1.6.2"
 	LatestVersionString     = "latest"
 )
 


### PR DESCRIPTION
Note: a regression appears to be present in 1.6.2 that was not present in 1.5.x: if a `terraform plan` is a mid-flow and the user sends the process a ctrl-c signal, the process exits without canceling the run on TFC/OTF. However, this regression only appears to impact `terraform plan` and not `terraform apply`.

Another note: one of the integration tests for the recently added github app was improperly implemented and would transiently fail. In order to get this PR through, I've fixed it here.