### PR TITLE
fix: skip reporting runs created via API

### DIFF
--- a/internal/run/reporter.go
+++ b/internal/run/reporter.go
@@ -68,8 +68,8 @@ func (r *Reporter) Start(ctx context.Context) error {
 }
 
 func (r *Reporter) handleRun(ctx context.Context, run *Run) error {
-	// Skip runs triggered via the UI
-	if run.Source == SourceUI {
+	// Skip runs triggered via the UI or API
+	if run.Source == SourceUI || run.Source == SourceAPI {
 		return nil
 	}
 

--- a/internal/run/reporter_test.go
+++ b/internal/run/reporter_test.go
@@ -57,6 +57,11 @@ func TestReporter_HandleRun(t *testing.T) {
 			run:  &Run{ID: "run-123", Source: SourceUI},
 			want: vcs.SetStatusOptions{},
 		},
+		{
+			name: "skip API-triggered run",
+			run:  &Run{ID: "run-123", Source: SourceAPI},
+			want: vcs.SetStatusOptions{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #618