### PR TITLE
fix: fixed defect with multiline tfvars not being escaped

### DIFF
--- a/internal/variable/variable.go
+++ b/internal/variable/variable.go
@@ -281,6 +281,15 @@ func WriteTerraformVars(dir string, vars []*Variable) error {
 			b.WriteString(" = ")
 			if v.HCL {
 				b.WriteString(v.Value)
+			} else if strings.Contains(v.Value, "\n") {
+				delimiter := "EOT"
+				for strings.Contains(v.Value, delimiter) {
+					delimiter = delimiter + "T"
+				}
+
+				b.WriteString("<<" + delimiter + "\n")
+				b.WriteString(v.Value)
+				b.WriteString("\n" + delimiter)
 			} else {
 				b.WriteString(`"`)
 				b.WriteString(v.Value)

--- a/internal/variable/variable_test.go
+++ b/internal/variable/variable_test.go
@@ -126,6 +126,7 @@ func TestWriteTerraformVariables(t *testing.T) {
 		Category: VariableCategoryPtr(CategoryTerraform),
 	})
 	require.NoError(t, err)
+
 	v2, err := newVariable(nil, CreateVariableOptions{
 		Key: internal.String("images"),
 		Value: internal.String(`{
@@ -138,7 +139,21 @@ func TestWriteTerraformVariables(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = WriteTerraformVars(dir, []*Variable{v1, v2})
+	v3, err := newVariable(nil, CreateVariableOptions{
+		Key:      internal.String("multiline-foo"),
+		Value:    internal.String("foo\nbar\nbaz"),
+		Category: VariableCategoryPtr(CategoryTerraform),
+	})
+	require.NoError(t, err)
+
+	v4, err := newVariable(nil, CreateVariableOptions{
+		Key:      internal.String("multiline-foo-with-delimiter"),
+		Value:    internal.String("EOTfoo\nbar\nbaz"),
+		Category: VariableCategoryPtr(CategoryTerraform),
+	})
+	require.NoError(t, err)
+
+	err = WriteTerraformVars(dir, []*Variable{v1, v2, v3, v4})
 	require.NoError(t, err)
 
 	tfvars := path.Join(dir, "terraform.tfvars")
@@ -151,6 +166,16 @@ images = {
     us-east-1 = "image-1234"
     us-west-2 = "image-4567"
 }
+multiline-foo = <<EOT
+foo
+bar
+baz
+EOT
+multiline-foo-with-delimiter = <<EOTT
+EOTfoo
+bar
+baz
+EOTT
 `
 	assert.Equal(t, want, string(got))
 }


### PR DESCRIPTION
This PR resolves #630 by using heredocs in variables when that variable includes a newline. 

This PR isn't intended to fix all escaping with the WriteTerraformVars function, and there are other ways that this can be broken (for example using backspaces and double quotes within the value of the variable)