### PR TITLE
fix: Add missing CancelRunAction to WorkspaceWriteRole

### DIFF
--- a/internal/rbac/role.go
+++ b/internal/rbac/role.go
@@ -66,6 +66,7 @@ var (
 		name: "write",
 		permissions: map[Action]bool{
 			ApplyRunAction:                        true,
+			CancelRunAction:                       true,
 			LockWorkspaceAction:                   true,
 			UnlockWorkspaceAction:                 true,
 			CreateWorkspaceVariableAction:         true,

--- a/internal/rbac/role_test.go
+++ b/internal/rbac/role_test.go
@@ -12,12 +12,14 @@ func TestRole_IsAllowed(t *testing.T) {
 	assert.True(t, WorkspacePlanRole.IsAllowed(TailLogsAction))
 
 	assert.True(t, WorkspaceWriteRole.IsAllowed(ApplyRunAction))
+	assert.True(t, WorkspaceWriteRole.IsAllowed(CancelRunAction))
 	assert.True(t, WorkspaceWriteRole.IsAllowed(CreateRunAction))
 	assert.True(t, WorkspaceWriteRole.IsAllowed(ListRunsAction))
 	assert.True(t, WorkspaceWriteRole.IsAllowed(TailLogsAction))
 
 	assert.True(t, WorkspaceAdminRole.IsAllowed(SetWorkspacePermissionAction))
 	assert.True(t, WorkspaceAdminRole.IsAllowed(ApplyRunAction))
+	assert.True(t, WorkspaceWriteRole.IsAllowed(CancelRunAction))
 	assert.True(t, WorkspaceAdminRole.IsAllowed(CreateRunAction))
 	assert.True(t, WorkspaceAdminRole.IsAllowed(ListRunsAction))
 	assert.True(t, WorkspaceAdminRole.IsAllowed(TailLogsAction))
@@ -25,6 +27,7 @@ func TestRole_IsAllowed(t *testing.T) {
 	assert.True(t, WorkspaceManagerRole.IsAllowed(CreateWorkspaceAction))
 	assert.True(t, WorkspaceManagerRole.IsAllowed(SetWorkspacePermissionAction))
 	assert.True(t, WorkspaceManagerRole.IsAllowed(ApplyRunAction))
+	assert.True(t, WorkspaceWriteRole.IsAllowed(CancelRunAction))
 	assert.True(t, WorkspaceManagerRole.IsAllowed(CreateRunAction))
 	assert.True(t, WorkspaceManagerRole.IsAllowed(ListRunsAction))
 	assert.True(t, WorkspaceManagerRole.IsAllowed(TailLogsAction))


### PR DESCRIPTION
We have encountered the issue that a team member with permission to manage workspace cannot cancel a pending run. This PR adds the missing `CancelRunAction` to the `WorkspaceWriteRole`.