### PR TITLE
add extra case for gitlab repo dir name

### DIFF
--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -166,14 +166,14 @@ func (g *Client) GetRepoTarball(ctx context.Context, opts vcs.GetRepoTarballOpti
 	}
 	dir := contents[0].Name()
 	parts := strings.Split(dir, "-")
-	if len(parts) != 2 {
+	if (len(parts) < 2) || (len(parts) > 3) {
 		return nil, "", fmt.Errorf("malformed directory name found in tarball: %s", dir)
 	}
 	tarball, err = internal.Pack(path.Join(untarpath, dir))
 	if err != nil {
 		return nil, "", err
 	}
-	return tarball, parts[1], nil
+	return tarball, parts[len(parts)-1], nil
 }
 
 func (g *Client) CreateWebhook(ctx context.Context, opts vcs.CreateWebhookOptions) (string, error) {


### PR DESCRIPTION
This was a small change we had to make for solving the issue with #651 wherein we see a different name structure for the directory within the tarball that we get from gitlab