### PR TITLE
fix: organization tokens

### DIFF
--- a/internal/integration/organization_token_test.go
+++ b/internal/integration/organization_token_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/leg100/otf/internal"
+	"github.com/leg100/otf/internal/api"
+	"github.com/leg100/otf/internal/organization"
+	"github.com/leg100/otf/internal/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_OrganizationTokens demonstrates the use of an organization
+// token to authenticate via the API.
+func TestIntegration_OrganizationTokens(t *testing.T) {
+	integrationTest(t)
+
+	daemon, org, ctx := setup(t, nil)
+
+	ot, token, err := daemon.CreateOrganizationToken(ctx, organization.CreateOrganizationTokenOptions{
+		Organization: org.Name,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, org.Name, ot.Organization)
+
+	apiClient, err := api.NewClient(api.Config{
+		Address: daemon.Hostname(),
+		Token:   string(token),
+	})
+	require.NoError(t, err)
+
+	// create some workspaces and attempt to list them using client
+	// authenticating with an organization token
+	daemon.createWorkspace(t, ctx, org)
+	daemon.createWorkspace(t, ctx, org)
+	daemon.createWorkspace(t, ctx, org)
+
+	wsClient := &workspace.Client{Client: apiClient}
+	got, err := wsClient.ListWorkspaces(ctx, workspace.ListOptions{
+		Organization: internal.String(org.Name),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(got.Items))
+
+	// re-generate token
+	_, _, err = daemon.CreateOrganizationToken(ctx, organization.CreateOrganizationTokenOptions{
+		Organization: org.Name,
+	})
+	require.NoError(t, err)
+
+	// access with previous token should now be refused
+	_, err = wsClient.ListWorkspaces(ctx, workspace.ListOptions{
+		Organization: internal.String(org.Name),
+	})
+	require.Equal(t, internal.ErrUnauthorized, err)
+}

--- a/internal/organization/web.go
+++ b/internal/organization/web.go
@@ -239,12 +239,16 @@ func (a *web) organizationToken(w http.ResponseWriter, r *http.Request) {
 		a.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	token, err := a.svc.GetOrganizationToken(r.Context(), org)
+	// ListOrganizationTokens should only ever return either 0 or 1 token
+	tokens, err := a.svc.ListOrganizationTokens(r.Context(), org)
 	if err != nil {
 		a.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
+	var token *OrganizationToken
+	if len(tokens) > 0 {
+		token = tokens[0]
+	}
 	a.Render("organization_token.tmpl", w, struct {
 		OrganizationPage
 		Token *OrganizationToken

--- a/internal/sql/pggen/agent.sql.go
+++ b/internal/sql/pggen/agent.sql.go
@@ -578,12 +578,19 @@ type Querier interface {
 	// UpsertOrganizationTokenScan scans the result of an executed UpsertOrganizationTokenBatch query.
 	UpsertOrganizationTokenScan(results pgx.BatchResults) (pgconn.CommandTag, error)
 
-	FindOrganizationTokensByName(ctx context.Context, organizationName pgtype.Text) ([]FindOrganizationTokensByNameRow, error)
+	FindOrganizationTokens(ctx context.Context, organizationName pgtype.Text) ([]FindOrganizationTokensRow, error)
+	// FindOrganizationTokensBatch enqueues a FindOrganizationTokens query into batch to be executed
+	// later by the batch.
+	FindOrganizationTokensBatch(batch genericBatch, organizationName pgtype.Text)
+	// FindOrganizationTokensScan scans the result of an executed FindOrganizationTokensBatch query.
+	FindOrganizationTokensScan(results pgx.BatchResults) ([]FindOrganizationTokensRow, error)
+
+	FindOrganizationTokensByName(ctx context.Context, organizationName pgtype.Text) (FindOrganizationTokensByNameRow, error)
 	// FindOrganizationTokensByNameBatch enqueues a FindOrganizationTokensByName query into batch to be executed
 	// later by the batch.
 	FindOrganizationTokensByNameBatch(batch genericBatch, organizationName pgtype.Text)
 	// FindOrganizationTokensByNameScan scans the result of an executed FindOrganizationTokensByNameBatch query.
-	FindOrganizationTokensByNameScan(results pgx.BatchResults) ([]FindOrganizationTokensByNameRow, error)
+	FindOrganizationTokensByNameScan(results pgx.BatchResults) (FindOrganizationTokensByNameRow, error)
 
 	FindOrganizationTokensByID(ctx context.Context, organizationTokenID pgtype.Text) (FindOrganizationTokensByIDRow, error)
 	// FindOrganizationTokensByIDBatch enqueues a FindOrganizationTokensByID query into batch to be executed
@@ -1841,6 +1848,9 @@ func PrepareAllQueries(ctx context.Context, p preparer) error {
 	}
 	if _, err := p.Prepare(ctx, upsertOrganizationTokenSQL, upsertOrganizationTokenSQL); err != nil {
 		return fmt.Errorf("prepare query 'UpsertOrganizationToken': %w", err)
+	}
+	if _, err := p.Prepare(ctx, findOrganizationTokensSQL, findOrganizationTokensSQL); err != nil {
+		return fmt.Errorf("prepare query 'FindOrganizationTokens': %w", err)
 	}
 	if _, err := p.Prepare(ctx, findOrganizationTokensByNameSQL, findOrganizationTokensByNameSQL); err != nil {
 		return fmt.Errorf("prepare query 'FindOrganizationTokensByName': %w", err)

--- a/internal/sql/queries/organization_token.sql
+++ b/internal/sql/queries/organization_token.sql
@@ -14,7 +14,12 @@ INSERT INTO organization_tokens (
       organization_token_id = pggen.arg('organization_token_id'),
       expiry                = pggen.arg('expiry');
 
--- name: FindOrganizationTokensByName :many
+-- name: FindOrganizationTokens :many
+SELECT *
+FROM organization_tokens
+WHERE organization_name = pggen.arg('organization_name');
+
+-- name: FindOrganizationTokensByName :one
 SELECT *
 FROM organization_tokens
 WHERE organization_name = pggen.arg('organization_name');

--- a/internal/tokens/middleware.go
+++ b/internal/tokens/middleware.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/leg100/otf/internal"
 	otfapi "github.com/leg100/otf/internal/api"
@@ -35,6 +36,7 @@ var AuthenticatedPrefixes = []string{
 type (
 	middlewareOptions struct {
 		GoogleIAPConfig
+		logr.Logger
 
 		key jwk.Key
 
@@ -94,6 +96,7 @@ func newMiddleware(opts middlewareOptions) mux.MiddlewareFunc {
 			} else if bearer := r.Header.Get("Authorization"); bearer != "" {
 				subject, err = mw.validateBearer(ctx, bearer)
 				if err != nil {
+					mw.Error(err, "validating bearer token")
 					http.Error(w, err.Error(), http.StatusUnauthorized)
 					return
 				}

--- a/internal/tokens/middleware_test_helpers.go
+++ b/internal/tokens/middleware_test_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/leg100/otf/internal"
+	"github.com/leg100/otf/internal/logr"
 	"github.com/leg100/otf/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,8 @@ func fakeTokenMiddleware(t *testing.T, secret []byte) mux.MiddlewareFunc {
 
 	key := newTestJWK(t, secret)
 	return newMiddleware(middlewareOptions{
-		key: key,
+		Logger: logr.Discard(),
+		key:    key,
 		registry: &registry{
 			kinds: map[Kind]SubjectGetter{
 				"test-kind": func(context.Context, string) (internal.Subject, error) {
@@ -68,6 +70,7 @@ func fakeSiteTokenMiddleware(t *testing.T, token string) mux.MiddlewareFunc {
 
 	key := newTestJWK(t, testutils.NewSecret(t)) // not used but constructor requires it
 	return newMiddleware(middlewareOptions{
+		Logger:   logr.Discard(),
 		registry: &registry{SiteToken: token, SiteAdmin: &internal.Superuser{}},
 		key:      key,
 	})
@@ -78,6 +81,7 @@ func fakeIAPMiddleware(t *testing.T, aud string) mux.MiddlewareFunc {
 
 	key := newTestJWK(t, testutils.NewSecret(t)) // not used but constructor requires it
 	return newMiddleware(middlewareOptions{
+		Logger: logr.Discard(),
 		registry: &registry{
 			uiSubjectGetterOrCreator: func(context.Context, string) (internal.Subject, error) {
 				return &internal.Superuser{}, nil

--- a/internal/tokens/service.go
+++ b/internal/tokens/service.go
@@ -55,6 +55,7 @@ func NewService(opts Options) (*service, error) {
 		kinds: make(map[Kind]SubjectGetter),
 	}
 	svc.middleware = newMiddleware(middlewareOptions{
+		Logger:          opts.Logger,
 		GoogleIAPConfig: opts.GoogleIAPConfig,
 		key:             key,
 		registry:        svc.registry,


### PR DESCRIPTION
Organization tokens have been broken since they were refactored in 104013d4. The JWT contains the _organization token_ _ID_ but the middleware was checking the _organization_ _name_.

Might fix #658.
