### PR TITLE
fix: allocator restarting unnecessarily

### DIFF
--- a/internal/agent/allocator.go
+++ b/internal/agent/allocator.go
@@ -151,7 +151,8 @@ func (a *allocator) allocate(ctx context.Context) error {
 			a.agents[*job.AgentID].CurrentJobs--
 			continue
 		default:
-			return fmt.Errorf("unknown job status: %s", job.Status)
+			// job running; ignore
+			continue
 		}
 		// allocate job to available agent
 		var available []*Agent

--- a/internal/agent/allocator_test.go
+++ b/internal/agent/allocator_test.go
@@ -166,6 +166,14 @@ func TestAllocator_allocate(t *testing.T) {
 			wantJob:    nil,
 			wantAgents: map[string]*Agent{"agent-1": {ID: "agent-1", CurrentJobs: 0}},
 		},
+		{
+			name: "ignore running job",
+			job: &Job{
+				Spec:    JobSpec{RunID: "run-123", Phase: internal.PlanPhase},
+				Status:  JobRunning,
+				AgentID: internal.String("agent-1"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes an issue whereby everytime a job runs the allocator service would restart.