### PR TITLE
fix: avoid hitting Github limit on commit status updates

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -480,6 +480,7 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 				Workspaces:      d.Workspaces,
 				Runs:            d.Runs,
 				Configs:         d.Configs,
+				Cache:           make(map[string]vcs.Status),
 			},
 		},
 		{

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,14 +2,13 @@ package github
 
 import (
 	"context"
-	"sort"
-
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -190,7 +189,7 @@ func (g *Client) ListRepositories(ctx context.Context, opts vcs.ListRepositories
 		// Apps.ListRepos endpoint does not support ordering on the server-side,
 		// so instead we request *all* repos, page-by-page, and then sort
 		// client-side.
-		var page = 1
+		page := 1
 		for {
 			result, resp, err := g.client.Apps.ListRepos(ctx, &github.ListOptions{
 				PerPage: opts.PageSize,
@@ -448,7 +447,7 @@ func (g *Client) SetStatus(ctx context.Context, opts vcs.SetStatusOptions) error
 
 	var status string
 	switch opts.Status {
-	case vcs.PendingStatus, vcs.RunningStatus:
+	case vcs.PendingStatus:
 		status = "pending"
 	case vcs.SuccessStatus:
 		status = "success"

--- a/internal/integration/connect_repo_e2e_test.go
+++ b/internal/integration/connect_repo_e2e_test.go
@@ -59,13 +59,8 @@ func TestConnectRepoE2E(t *testing.T) {
 		err = expect.Locator(page.Locator(`//div[@class='widget']//img[@id='run-trigger-github']`)).ToBeVisible()
 		require.NoError(t, err)
 
-		// GitHub should receive two pending status updates followed by a final
-		// update with details of planned resources. (The reason for two pending
-		// updates is that the run reporter de-dups status updates but only does
-		// so for OTF's abstract vcs.Status, which has a "running" value; but
-		// GitHub has no equivalent "running" value, so the Github client maps
-		// "running" to "pending"...).
-		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
+		// GitHub should receive one pending status update followed by a final
+		// update with details of planned resources.
 		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
 		got := daemon.GetStatus(t, ctx)
 		require.Equal(t, "success", got.GetState())

--- a/internal/integration/connect_repo_e2e_test.go
+++ b/internal/integration/connect_repo_e2e_test.go
@@ -59,10 +59,12 @@ func TestConnectRepoE2E(t *testing.T) {
 		err = expect.Locator(page.Locator(`//div[@class='widget']//img[@id='run-trigger-github']`)).ToBeVisible()
 		require.NoError(t, err)
 
-		// github should receive three pending status updates followed by a final
-		// update with details of planned resources
-		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
-		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
+		// GitHub should receive two pending status updates followed by a final
+		// update with details of planned resources. (The reason for two pending
+		// updates is that the run reporter de-dups status updates but only does
+		// so for OTF's abstract vcs.Status, which has a "running" value; but
+		// GitHub has no equivalent "running" value, so the Github client maps
+		// "running" to "pending"...).
 		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
 		require.Equal(t, "pending", daemon.GetStatus(t, ctx).GetState())
 		got := daemon.GetStatus(t, ctx)

--- a/internal/run/reporter.go
+++ b/internal/run/reporter.go
@@ -31,7 +31,9 @@ type (
 		// Cache most recently set status for each incomplete run to ensure the
 		// same status is not set more than once on an upstream VCS provider.
 		// This is important to avoid hitting rate limits on VCS providers, e.g.
-		// GitHub has a limit of 1000 status updates on a commit.
+		// GitHub has a limit of 1000 status updates on a commit:
+		//
+		// https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
 		//
 		// key is the run ID.
 		Cache map[string]vcs.Status

--- a/internal/run/reporter.go
+++ b/internal/run/reporter.go
@@ -109,10 +109,8 @@ func (r *Reporter) handleRun(ctx context.Context, run *Run) error {
 		description string
 	)
 	switch run.Status {
-	case RunPending, RunPlanQueued, RunApplyQueued:
+	case RunPending, RunPlanQueued, RunApplyQueued, RunPlanning, RunApplying, RunPlanned, RunConfirmed:
 		status = vcs.PendingStatus
-	case RunPlanning, RunApplying, RunPlanned, RunConfirmed:
-		status = vcs.RunningStatus
 	case RunPlannedAndFinished:
 		status = vcs.SuccessStatus
 		if run.Plan.ResourceReport != nil {

--- a/internal/run/reporter.go
+++ b/internal/run/reporter.go
@@ -68,7 +68,10 @@ func (r *Reporter) Start(ctx context.Context) error {
 			continue
 		}
 		if err := r.handleRun(ctx, event.Payload); err != nil {
-			return err
+			// any error is treated as non-fatal because reporting on runs is
+			// considered "best-effort" rather than an integral operation
+			r.Error(err, "reporting run vcs status", "run_id", event.Payload.ID)
+			return nil
 		}
 	}
 	return pubsub.ErrSubscriptionTerminated

--- a/internal/run/reporter_test.go
+++ b/internal/run/reporter_test.go
@@ -20,7 +20,9 @@ func TestReporter_HandleRun(t *testing.T) {
 		run  *Run
 		ws   *workspace.Workspace
 		cv   *configversion.ConfigurationVersion
-		want vcs.SetStatusOptions
+		// expect the given status options to be set. If nil then expect no
+		// status options to be set.
+		want *vcs.SetStatusOptions
 	}{
 		{
 			name: "set pending status",
@@ -35,7 +37,7 @@ func TestReporter_HandleRun(t *testing.T) {
 					Repo:      "leg100/otf",
 				},
 			},
-			want: vcs.SetStatusOptions{
+			want: &vcs.SetStatusOptions{
 				Workspace: "dev",
 				Ref:       "abc123",
 				Repo:      "leg100/otf",
@@ -49,17 +51,17 @@ func TestReporter_HandleRun(t *testing.T) {
 			cv: &configversion.ConfigurationVersion{
 				IngressAttributes: nil,
 			},
-			want: vcs.SetStatusOptions{},
+			want: nil,
 		},
 		{
 			name: "skip UI-triggered run",
 			run:  &Run{ID: "run-123", Source: SourceUI},
-			want: vcs.SetStatusOptions{},
+			want: nil,
 		},
 		{
 			name: "skip API-triggered run",
 			run:  &Run{ID: "run-123", Source: SourceAPI},
-			want: vcs.SetStatusOptions{},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -75,7 +77,11 @@ func TestReporter_HandleRun(t *testing.T) {
 			err := reporter.handleRun(ctx, tt.run)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.want, got)
+			if tt.want == nil {
+				assert.Equal(t, 0, len(got))
+			} else {
+				assert.Equal(t, *tt.want, <-got)
+			}
 		})
 	}
 }

--- a/internal/vcs/status.go
+++ b/internal/vcs/status.go
@@ -4,7 +4,6 @@ type Status string
 
 const (
 	PendingStatus Status = "pending"
-	RunningStatus Status = "running"
 	SuccessStatus Status = "success"
 	ErrorStatus   Status = "error"
 	FailureStatus Status = "failure"


### PR DESCRIPTION
#685 reports the Github limit of 1000 commit status updates being routinely hit.

This PR does too things to avoid this limit being hit:
*  ensures the same status update is not sent more than once, thanks to the use of a cache.
* removes the `running` abstract VCS status, for which Github has no equivalent, and is not actually used anywhere else in OTF