### PR TITLE
fix: don't unnecessarily restart scheduler

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -177,8 +177,12 @@ func (s *scheduler) handleRunEvent(ctx context.Context, event pubsub.Event[*run.
 	}
 	q, ok := s.queues[event.Payload.WorkspaceID]
 	if !ok {
-		// should never happen
-		s.Error(nil, "workspace queue does not exist for run event", "workspace", event.Payload.WorkspaceID, "run", event.Payload.ID, "event", event.Type)
+		// No queue exists for the workspace because the workspace has
+		// since been deleted, which can occur when run events arrive *after*
+		// the "workspace deleted" event, which is entirely possible with the
+		// way the scheduler processes events.
+		//
+		// In this case no action need be taken on the run.
 		return nil
 	}
 	if err := q.handleRun(ctx, event.Payload); err != nil {

--- a/internal/workspace/lock_db.go
+++ b/internal/workspace/lock_db.go
@@ -38,9 +38,9 @@ func (db *pgdb) toggleLock(ctx context.Context, workspaceID string, togglefn fun
 			}
 		}
 		if err := q.UpdateWorkspaceLockByID(ctx, params); err != nil {
-			return sql.Error(err)
+			return err
 		}
 		return nil
 	})
-	return ws, err
+	return ws, sql.Error(err)
 }


### PR DESCRIPTION
The scheduler ensures only one run on each workspace is permitted to be running (the exception to this rule are "plan-only" runs, which we won't discuss here). A run begins in the `pending` state. It cannot transition to the next state, `plan_queued`, until:

(a) any other pending runs created before it have finished.
(b) its workspace is unlocked.

Once both conditions are true, the scheduler does the following:

(a) locks the workspace 
(b) updates the status of the run to `plan_queued`
(c) sets the run as the "current run" of the workspace

Once a run finishes it is also responsible for unlocking the workspace once a run completes. One of the bugs identified by the user is a race condition that occurs whenever a run finishes and its workspace is immediately deleted (this is not an untypical scenario, where you're testing changes on an "ephemeral" workspace): the scheduler receives the "run completed" event and often by this time the workspace has already been deleted, but the scheduler isn't aware of that, and it tries to unlock the workspace and it receives an error. This shouldn't be an issue because the error is "workspace not found" and the scheduler should understand that that means the workspace has since been deleted, no action need be taken and to move on. But instead it errantly interpets it as a transient error, and backs off and retries. The fix here is clear.

Another race condition occurs when the "run completed" event is received *after* the "workspace deleted" event. The scheduler processes the latter event and deletes its cached workspace accordingly. It then receives the "run completed" event and tries to lookup its workspace in its cache and it cannot find it. It reports this as an error to the user, and moves on. The "fix" here is to either accept this as an entirely reasonable race condition and suppress the error message; or to make a change to ensure events are processed in order. In this case I've opted for the former.

#685 