### PR TITLE
Add --allowed-origins parameter

### DIFF
--- a/cmd/otfd/main.go
+++ b/cmd/otfd/main.go
@@ -81,6 +81,7 @@ func parseFlags(ctx context.Context, args []string, out io.Writer) error {
 	cmd.Flags().BytesHexVar(&cfg.Secret, "secret", nil, "Hex-encoded 16 byte secret for cryptographic work. Required.")
 	cmd.Flags().Int64Var(&cfg.MaxConfigSize, "max-config-size", cfg.MaxConfigSize, "Maximum permitted configuration size in bytes.")
 	cmd.Flags().StringVar(&cfg.WebhookHost, "webhook-hostname", "", "External hostname for otf webhooks")
+	cmd.Flags().StringVar(&cfg.AllowedOrigins, "allowed-origins", "", "Allowed origins for websocket upgrades")
 
 	cmd.Flags().IntVar(&cfg.CacheConfig.Size, "cache-size", 0, "Maximum cache size in MB. 0 means unlimited size.")
 	cmd.Flags().DurationVar(&cfg.CacheConfig.TTL, "cache-expiry", internal.DefaultCacheTTL, "Cache entry TTL.")

--- a/docs/docs/config/flags.md
+++ b/docs/docs/config/flags.md
@@ -118,6 +118,20 @@ It is highly advisable to set this flag in a production deployment.
 
 Sets the hostname that VCS providers can use to access the OTF webhooks.
 
+## `--allowed-origins`
+
+* System: `otfd`
+* Default: ""
+
+Specifies a comma-separated list of hostnames which are checked
+against the Origin: header for websocket upgrades.
+
+By default, websocket upgrade requests are validated by comparing the
+Origin: and Host: headers.  This works for direct connections, but can fail
+in reverse proxy configurations.
+
+This parameter provides a list of valid hostnames to check Origin: against.
+
 ## `--log-format`
 
 * System: `otfd`, `otf-agent`

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	WebhookHost                  string
 	Address                      string
 	Database                     string
+	AllowedOrigins               string
 	MaxConfigSize                int64
 	SSL                          bool
 	CertFile, KeyFile            string

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -434,6 +434,7 @@ func (d *Daemon) Start(ctx context.Context, started chan struct{}) error {
 		EnableRequestLogging: d.EnableRequestLogging,
 		Middleware:           []mux.MiddlewareFunc{d.Tokens.Middleware()},
 		Handlers:             d.handlers,
+		AllowedOrigins:       d.AllowedOrigins,
 	})
 	if err != nil {
 		return fmt.Errorf("setting up http server: %w", err)

--- a/internal/http/html/components/websocket.go
+++ b/internal/http/html/components/websocket.go
@@ -14,6 +14,9 @@ var upgrader = websocket.Upgrader{
 }
 
 func SetAllowedOrigins(origins string) {
+	if len(origins) == 0 {
+		return
+	}
 	sl := strings.Split(strings.ToLower(origins), ",")
 	sm := map[string]bool{}
 	for _, o := range sl {

--- a/internal/http/html/components/websocket.go
+++ b/internal/http/html/components/websocket.go
@@ -1,0 +1,39 @@
+package components
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func SetAllowedOrigins(origins string) {
+	sl := strings.Split(strings.ToLower(origins), ",")
+	sm := map[string]bool{}
+	for _, o := range sl {
+		o = strings.TrimPrefix(o, "https://")
+		o = strings.TrimPrefix(o, "http://")
+		sm[o] = true
+	}
+	if len(sm) > 0 {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			origins := r.Header["Origin"]
+			if len(origins) == 0 {
+				return true
+			}
+			u, err := url.Parse(origins[0])
+			if err != nil {
+				return false
+			}
+			origin := strings.ToLower(u.Host)
+			_, ok := sm[origin]
+			return ok
+		}
+	}
+}

--- a/internal/http/html/components/websocket_list_handler.go
+++ b/internal/http/html/components/websocket_list_handler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-
+	"strings"
 	"sync"
 	"time"
 
@@ -36,6 +36,31 @@ type WebsocketListHandler[Resource any, Options any] struct {
 type websocketListHandlerClient[Resource any, Options any] interface {
 	Watch(ctx context.Context) (<-chan pubsub.Event[Resource], func())
 	List(ctx context.Context, opts Options) (*resource.Page[Resource], error)
+}
+
+func SetAllowedOrigins(origins string) {
+	sl := strings.Split(strings.ToLower(origins), ",")
+	sm := map[string]bool{}
+	for _, o := range sl {
+		o = strings.TrimPrefix(o, "https://")
+		o = strings.TrimPrefix(o, "http://")
+		sm[o] = true
+	}
+	if len(sm) > 0 {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			origins := r.Header["Origin"]
+			if len(origins) == 0 {
+				return true
+			}
+			u, err := url.Parse(origins[0])
+			if err != nil {
+				return false
+			}
+			origin := strings.ToLower(u.Host)
+			_, ok := sm[origin]
+			return ok
+		}
+	}
 }
 
 func (h *WebsocketListHandler[Resource, Options]) Handler(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/http/html"
+	"github.com/leg100/otf/internal/http/html/components"
 	"github.com/leg100/otf/internal/json"
 )
 
@@ -42,6 +43,7 @@ type (
 		SSL                  bool
 		CertFile, KeyFile    string
 		EnableRequestLogging bool
+		AllowedOrigins       string
 
 		Handlers []internal.Handlers
 		// middleware to intercept requests, executed in the order given.
@@ -125,6 +127,8 @@ func NewServer(logger logr.Logger, cfg ServerConfig) (*Server, error) {
 			})
 		})
 	}
+
+	components.SetAllowedOrigins(cfg.AllowedOrigins)
 
 	return &Server{
 		Logger:       logger,


### PR DESCRIPTION
Fixes: #772

This gives otfd users a way to specify a comma-separated list of hostnames to validate websocket upgrade requests against.

Add a command-line parameter (`--allowed-origins`), add it to markdown docs, pass it through, split by commas, put the hostnames in a map, give `websocket.Upgrader` a callback to check for the Origin hostname's presence in the map.

A possible alternative would be to just return true in all cases.  That would make this patch much simpler; effectively a one-liner.