### PR TITLE
Fix the "Save variable set" button on the variableset edit page

### DIFF
--- a/internal/integration/variable_set_ui_test.go
+++ b/internal/integration/variable_set_ui_test.go
@@ -47,6 +47,18 @@ func TestIntegration_VariableSetUI(t *testing.T) {
 		err = expect.Locator(page.GetByRole("alert")).ToHaveText("added variable set: global-1")
 		require.NoError(t, err)
 
+		// edit description
+		err = page.Locator("textarea#description").Fill("this is my newly updated global variable set")
+		require.NoError(t, err)
+
+		// submit form
+		err = page.Locator(`//button[@id='save-variable-set-button']`).Click()
+		require.NoError(t, err)
+
+		// confirm variable set updated
+		err = expect.Locator(page.GetByRole("alert")).ToHaveText("updated variable set: global-1")
+		require.NoError(t, err)
+
 		// add a variable
 		err = page.Locator(`//button[@id='add-variable-button']`).Click()
 		require.NoError(t, err)

--- a/internal/variable/view.templ
+++ b/internal/variable/view.templ
@@ -236,7 +236,7 @@ templ editVariableSet(props editVariableSetProps) {
 		@variableSetForm(variableSetFormProps{
 			set:                 props.set,
 			edit:                true,
-			action:              paths.EditVariableSet(props.set.ID),
+			action:              paths.UpdateVariableSet(props.set.ID),
 			availableWorkspaces: props.availableWorkspaces,
 			existingWorkspaces:  props.existingWorkspaces,
 		})

--- a/internal/variable/view_templ.go
+++ b/internal/variable/view_templ.go
@@ -683,7 +683,7 @@ func editVariableSet(props editVariableSetProps) templ.Component {
 			templ_7745c5c3_Err = variableSetForm(variableSetFormProps{
 				set:                 props.set,
 				edit:                true,
-				action:              paths.EditVariableSet(props.set.ID),
+				action:              paths.UpdateVariableSet(props.set.ID),
 				availableWorkspaces: props.availableWorkspaces,
 				existingWorkspaces:  props.existingWorkspaces,
 			}).Render(ctx, templ_7745c5c3_Buffer)


### PR DESCRIPTION
When editing a variable set, the form has the wrong action URL.  Clicking the "Save" button results in a 404 error.

The form tries to submit to `.../edit`, but that's a GET endpoint.  The POST endpoint is `.../update`.  See the route definitions [here](https://github.com/leg100/otf/blob/master/internal/variable/web.go#L88-L89).

This patch fixes the form to submit to the right place.