### PR TITLE
fix(ui): Hide sensitive outputs on the workspaces page

### DIFF
--- a/internal/state/view.templ
+++ b/internal/state/view.templ
@@ -51,7 +51,13 @@ templ get(f *File) {
 						<tr>
 							<td>{ k }</td>
 							<td>{ v.Type() }</td>
-							<td><span class="bg-base-300">{ v.StringValue() }</span></td>
+							<td><span class="bg-base-300">
+								if v.Sensitive {
+									{ "******" }
+								} else {
+									{ v.StringValue() }
+								}
+							</span></td>
 						</tr>
 					}
 					if len(f.Outputs) == 0 {

--- a/internal/state/view_templ.go
+++ b/internal/state/view_templ.go
@@ -180,14 +180,26 @@ func get(f *File) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(v.StringValue())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/state/view.templ`, Line: 54, Col: 54}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if v.Sensitive {
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("******")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/state/view.templ`, Line: 56, Col: 19}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(v.StringValue())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/state/view.templ`, Line: 58, Col: 26}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span></td></tr>")
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
This matches the behavior of sensitive variables.  Users can still use the terraform/tofu command line tool to retrieve sensitive outputs.