### PR TITLE
fix: AWS dynamic provider credentials invalid apply absolute paths

### DIFF
--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -258,7 +258,7 @@ func (o *operation) do() error {
 	if err != nil {
 		return fmt.Errorf("retreiving workspace: %w", err)
 	}
-	wd, err := newWorkdir(ws.WorkingDirectory)
+	wd, err := newWorkdir(ws.WorkingDirectory, o.job.RunID.String())
 	if err != nil {
 		return fmt.Errorf("constructing working directory: %w", err)
 	}

--- a/internal/runner/workdir.go
+++ b/internal/runner/workdir.go
@@ -14,6 +14,10 @@ type workdir struct {
 
 func newWorkdir(workingDirectory string, RunID string) (*workdir, error) {
 	// create dedicated directory for run
+	// The absolute path needs to be consistent between operations, in order to
+	// avoid errors during apply for resources/variables that reference it since
+	// the saved plan locks in those values.
+	// ref: https://github.com/leg100/otf/pull/822
 	rootDir := path.Join(os.TempDir(), "otf-runs", RunID)
 	err := os.MkdirAll(rootDir, 0o700)
 	if err != nil {

--- a/internal/runner/workdir.go
+++ b/internal/runner/workdir.go
@@ -12,9 +12,10 @@ type workdir struct {
 	relative string // relative path to working directory
 }
 
-func newWorkdir(workingDirectory string) (*workdir, error) {
-	// create dedicated directory for operation
-	rootDir, err := os.MkdirTemp("", "otf-config-")
+func newWorkdir(workingDirectory string, RunID string) (*workdir, error) {
+	// create dedicated directory for run
+	rootDir := path.Join(os.TempDir(), "otf-runs", RunID)
+	err := os.MkdirAll(rootDir, 0o700)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes an issue with aws dynamic provider credentials.

A new tmpdir is created for each operation, so the absolute path for plan will be different than apply. The apply step uses the plan output, which means it doesn't read the inputs (I think?). Which means it wouldn't use the newly generated config/creds for the provider dynamic credentials and would try to look in the old path (which no longer existed).

The changing path also means that any files or values created during the plan will run into issues if they contain the absolute path. For example, the aws profile references another file by absolute path.