### PR TITLE
Update Alpine to v3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.23
 
 # git permits pulling modules via the git protocol
 RUN apk add --no-cache git

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.23
 
 # git permits pulling modules via the git protocol
 RUN apk add --no-cache git


### PR DESCRIPTION
Alpine 3.17 went [EOL November 2024](https://alpinelinux.org/releases/).

I did not test this (not familiar with the build/testing process here)—however, for my own use case I am building a custom otfd image with a Dockerfile based on alpine:3.23 and pulling `/usr/local/bin/otfd` from the `leg100/otfd:0.4.9` image, and it works.