### PR TITLE
check for TagsRegex being an empty string before throwing an error

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -260,7 +260,7 @@ func (f *factory) NewWorkspace(ctx context.Context, opts CreateOptions) (*Worksp
 	if opts.TriggerPrefixes != nil {
 		ws.TriggerPrefixes = opts.TriggerPrefixes
 	}
-	// Enforce three-way mutually exclusivity between:
+	// Enforce three-way mutual exclusivity between:
 	// (a) tags-regex
 	// (b) trigger-patterns
 	// (c) always-trigger=true
@@ -422,7 +422,7 @@ func (ws *Workspace) Update(opts UpdateOptions) (*bool, error) {
 		ws.TriggerPrefixes = opts.TriggerPrefixes
 		updated = true
 	}
-	// Enforce three-way mutually exclusivity between:
+	// Enforce three-way mutual exclusivity between:
 	// (a) tags-regex
 	// (b) trigger-patterns
 	// (c) always-trigger=true
@@ -474,7 +474,7 @@ func (ws *Workspace) Update(opts UpdateOptions) (*bool, error) {
 			updated = true
 		} else {
 			// modify existing connection
-			if (opts.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "") {
+			if opts.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "" {
 				if err := ws.setTagsRegex(*opts.TagsRegex); err != nil {
 					return nil, fmt.Errorf("invalid tags-regex: %w", err)
 				}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -75,10 +75,26 @@ func TestNewWorkspace(t *testing.T) {
 				Organization:    &org1,
 				TriggerPatterns: []string{"/foo/**/*.tf"},
 				ConnectOptions: &ConnectOptions{
-					TagsRegex: internal.Ptr("\\d+"),
+					RepoPath:      internal.Ptr(vcs.NewMustRepo("leg100", "otf")),
+					VCSProviderID: &vcsProviderID,
+					TagsRegex:     internal.Ptr("\\d+"),
 				},
 			},
 			wantError: ErrTagsRegexAndTriggerPatterns,
+		},
+		{
+			name: "specifying trigger patterns but empty string for tags regex is ok",
+			opts: CreateOptions{
+				Name:            internal.Ptr("my-workspace"),
+				Organization:    &org1,
+				TriggerPatterns: []string{"/foo/**/*.tf"},
+				ConnectOptions: &ConnectOptions{
+					RepoPath:      internal.Ptr(vcs.NewMustRepo("leg100", "otf")),
+					VCSProviderID: &vcsProviderID,
+					TagsRegex:     internal.Ptr(""),
+				},
+			},
+			wantError: nil,
 		},
 		{
 			name: "specifying both tags regex and always trigger",
@@ -200,10 +216,26 @@ func TestWorkspace_UpdateError(t *testing.T) {
 				Name:            internal.Ptr("my-workspace"),
 				TriggerPatterns: []string{"/foo/**/*.tf"},
 				ConnectOptions: &ConnectOptions{
-					TagsRegex: internal.Ptr("\\d+"),
+					RepoPath:      internal.Ptr(vcs.NewMustRepo("leg100", "otf")),
+					VCSProviderID: &vcsProviderID,
+					TagsRegex:     internal.Ptr("\\d+"),
 				},
 			},
 			want: ErrTagsRegexAndTriggerPatterns,
+		},
+		{
+			name: "specifying trigger patterns but empty string for tags regex is ok",
+			ws:   &Workspace{Name: "dev", Organization: org1},
+			opts: UpdateOptions{
+				Name:            internal.Ptr("my-workspace"),
+				TriggerPatterns: []string{"/foo/**/*.tf"},
+				ConnectOptions: &ConnectOptions{
+					RepoPath:      internal.Ptr(vcs.NewMustRepo("leg100", "otf")),
+					VCSProviderID: &vcsProviderID,
+					TagsRegex:     internal.Ptr(""),
+				},
+			},
+			want: nil,
 		},
 		{
 			name: "specifying both tags regex and always trigger",


### PR DESCRIPTION
(This is a revisit to my original fix for #679 - I had been running my own fork but would love to move back to upstream!)

This was a tweak that I had to make in order to allow workspaces with TriggerPatterns to be created/updated via the [tfe_workspace](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace) resource from the TFE provider. It seems that this value may be coming in as an empty string if not passed, which causes this error to be thrown, and which seems to get otf a bit confused (it will attempt to repeatedly try to create the workspace, but fail, and I think it queues up further plans? I ended up having to kill off otf and start fresh if i had an apply running trying to create workspaces in this way)!

Currently running this fork and I am able to create/edit these workspaces as expected!

Feel free to tweak if necessary, or let me know if there are any other ways you might want this case handled!