### PR TITLE
Set newer version of alpine and upgrade base packages in dockerfile to fix critical CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ FROM --platform=$BUILDPLATFORM alpine:3.23.3 AS base
 # https://docs.docker.com/build/cache/optimize/#use-cache-mounts Mounting
 # /etc/apk/cache with type=cache lets the image build system handle apk's cache
 # for us, without leaving any cache files in the image itself.
+
+# To Do: 
+#   - Update base image after CVEs are fixed
+#   - Remove apk update && apk upgrade (When the CVEs are fixed, this is no longer relevant)
 RUN --mount=type=cache,target=/etc/apk/cache \
   apk update && \
   apk upgrade --no-cache && \


### PR DESCRIPTION
**Summary:**
Update the Alpine base image and ensure base packages are upgraded during the Docker build to pull in upstream security fixes. This reduces the CVE surface area for all multi-stage targets (otfd, otf-agent, otf-job) since they all inherit from the shared base stage.

**Security impact**

These changes resolve the following vulnerabilities detected in the image:

CVE-2026-24515 (Critical) – libexpat updated 2.7.3-r0 → 2.7.4-r0

CVE-2026-25210 (Medium) – libexpat updated 2.7.3-r0 → 2.7.4-r0

CVE-2025-68121 – stdlib updated v1.25.6 → 1.25.7 (also fixed in 1.24.13 / 1.26.0-rc.3)

**Testing**

Built locally and deployed in kubernetes with no detected issues.
Verified updated packages are present in the resulting image (scanner output shows CVEs above are no longer reported)