### PR TITLE
fix: support subgroups in GitLab vcs provider.

### DIFF
--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -119,7 +119,7 @@ func (g *Client) ListRepositories(ctx context.Context, lopts vcs.ListRepositorie
 
 	repos := make([]vcs.Repo, len(projects))
 	for i, proj := range projects {
-		repos[i] = vcs.NewMustRepo(proj.Namespace.Path, proj.Path)
+		repos[i] = vcs.NewMustRepo(proj.Namespace.FullPath, proj.Path)
 	}
 	return repos, nil
 }
@@ -151,7 +151,7 @@ func (g *Client) GetRepoTarball(ctx context.Context, opts vcs.GetRepoTarballOpti
 	// Gitlab tarball contents are contained within a top-level directory
 	// formatted <ref>-<sha>. We want the tarball without this directory,
 	// so we re-tar the contents without the top-level directory.
-	untarpath, err := os.MkdirTemp("", fmt.Sprintf("gitlab-%s-%s-*", opts.Repo.Owner(), opts.Repo.Name()))
+	untarpath, err := os.MkdirTemp("", fmt.Sprintf("gitlab-%s-%s-*", strings.ReplaceAll(opts.Repo.Owner(), "/", "-"), opts.Repo.Name()))
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -125,7 +125,7 @@ func (g *Client) ListRepositories(ctx context.Context, lopts vcs.ListRepositorie
 }
 
 func (g *Client) ListTags(ctx context.Context, opts vcs.ListTagsOptions) ([]string, error) {
-	results, _, err := g.client.Tags.ListTags(opts.Repo, &gitlab.ListTagsOptions{
+	results, _, err := g.client.Tags.ListTags(opts.Repo.String(), &gitlab.ListTagsOptions{
 		Search: new("^" + opts.Prefix),
 	})
 	if err != nil {

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -54,13 +54,28 @@ func TestClient_ListRepositories(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
-		fmt.Fprint(w, `[{"namespace": {"path": "acme"}, "path":"terraform"}]`)
+		fmt.Fprint(w, `[{"namespace": {"full_path": "acme"}, "path":"terraform"}]`)
 	})
 
 	got, err := client.ListRepositories(context.Background(), vcs.ListRepositoriesOptions{})
 	require.NoError(t, err)
 
 	want := vcs.NewMustRepo("acme", "terraform")
+	assert.Equal(t, []vcs.Repo{want}, got)
+}
+
+func TestClient_ListRepositories_Subgroup(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "GET", r.Method)
+		fmt.Fprint(w, `[{"namespace": {"full_path": "acme/infra/team-a"}, "path":"terraform"}]`)
+	})
+
+	got, err := client.ListRepositories(context.Background(), vcs.ListRepositoriesOptions{})
+	require.NoError(t, err)
+
+	want := vcs.NewMustRepo("acme/infra/team-a", "terraform")
 	assert.Equal(t, []vcs.Repo{want}, got)
 }
 


### PR DESCRIPTION
Proposed fix for #919.

Updates namespace to use Fullpath and runs necessary replacement on owner when fetching the tarball for the repository.