### PR TITLE
feat: add job image flag for kubernetes executor

### DIFF
--- a/charts/libs/runner/README.md
+++ b/charts/libs/runner/README.md
@@ -14,7 +14,7 @@ A Helm chart library for otf runner resources and configuration.
 | cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
-| kubernetesJobImage | string | `nil` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
+| kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |
 | kubernetesLimitMemory | string | `nil` | Set a memory limit for kubernetes jobs. |

--- a/charts/libs/runner/README.md
+++ b/charts/libs/runner/README.md
@@ -14,6 +14,7 @@ A Helm chart library for otf runner resources and configuration.
 | cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| kubernetesJobImage | string | `nil` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |
 | kubernetesLimitMemory | string | `nil` | Set a memory limit for kubernetes jobs. |

--- a/charts/libs/runner/templates/_envs.yaml
+++ b/charts/libs/runner/templates/_envs.yaml
@@ -32,6 +32,10 @@
 - name: OTF_KUBERNETES_LIMIT_MEMORY
   value: {{ . }}
 {{- end }}
+{{- with .kubernetesJobImage }}
+- name: OTF_KUBERNETES_JOB_IMAGE
+  value: "{{ . }}"
+{{- end }}
 - name: OTF_ENGINE_BINS_DIR
   value: "/cache/engines"
 {{- with .pluginCache }}

--- a/charts/libs/runner/values.yaml
+++ b/charts/libs/runner/values.yaml
@@ -12,6 +12,8 @@ kubernetesLimitCPU: ~
 kubernetesLimitMemory: ~
 # -- Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`.
 kubernetesLabels: []
+# -- Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image).
+kubernetesJobImage: ~
 # -- Delete finished kubernetes jobs after this duration.
 kubernetesTTLAfterFinish:
 # -- (bool) Enable shared provider plugin cache for terraform providers. Note this is only concurrency safe in opentofu 1.10.0 and greater.

--- a/charts/libs/runner/values.yaml
+++ b/charts/libs/runner/values.yaml
@@ -13,7 +13,7 @@ kubernetesLimitMemory: ~
 # -- Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`.
 kubernetesLabels: []
 # -- Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image).
-kubernetesJobImage: ~
+kubernetesJobImage: ""
 # -- Delete finished kubernetes jobs after this duration.
 kubernetesTTLAfterFinish:
 # -- (bool) Enable shared provider plugin cache for terraform providers. Note this is only concurrency safe in opentofu 1.10.0 and greater.

--- a/charts/otf-agent/README.md
+++ b/charts/otf-agent/README.md
@@ -89,6 +89,7 @@ address=10.244.0.18 agent.pool_id=apool-5b90443ed82ef769
 | runner.cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | runner.concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | runner.executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| runner.kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | runner.kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | runner.kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |
 | runner.kubernetesLimitMemory | string | `nil` | Set a memory limit for kubernetes jobs. |

--- a/charts/otfd/README.md
+++ b/charts/otfd/README.md
@@ -108,6 +108,7 @@ Note: you should only use this for testing purposes.
 | runner.cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | runner.concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | runner.executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| runner.kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | runner.kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | runner.kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |
 | runner.kubernetesLimitMemory | string | `nil` | Set a memory limit for kubernetes jobs. |

--- a/docs/docs/config/flags.md
+++ b/docs/docs/config/flags.md
@@ -128,6 +128,13 @@ Sets the hostname advertised to external clients, for example:
 
 It is advisable to set this flag in a production deployment. Otherwise it defaults to the listening address set with `--address` which is unlikely to be accessible to external clients.
 
+## `--kubernetes-job-image`
+
+* System: `otfd`, `otf-agent`
+* Default: `leg100/otf-job:<version>`
+
+Set the image used for kubernetes jobs. Allows customization of the job image so that you can add custom tools or logic to your run environments.
+
 ## `--kubernetes-request-cpu`
 
 * System: `otfd`, `otf-agent`

--- a/docs/docs/executors.md
+++ b/docs/docs/executors.md
@@ -25,9 +25,9 @@ This executor is only functional when `otfd` or `otf-agent` is deployed via the 
 
 There are a number of flags that customise the jobs:
 
+* [`--kubernetes-job-image`](config/flags.md#-kubernetes-job-image)
 * [`--kubernetes-request-cpu`](config/flags.md#-kubernetes-request-cpu)
 * [`--kubernetes-request-memory`](config/flags.md#-kubernetes-request-memory)
 * [`--kubernetes-ttl-after-finish`](config/flags.md#-kubernetes-ttl-after-finish)
 
 It's advisable to provide a persistent volume for the cache. Otherwise the terraform or tofu binary is downloaded at the beginning of every job. See the helm chart settings to enable the persistent volume claim. You will need to make available a persistent volume that supports the [ReadWriteMany](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) access mode.
-

--- a/internal/runner/executor_kube.go
+++ b/internal/runner/executor_kube.go
@@ -72,6 +72,7 @@ var (
 	defaultKubeConfig kubeConfig
 )
 
+
 type kubeConfig struct {
 	Namespace      string
 	Image          string
@@ -101,13 +102,13 @@ type kubeConfigFlags struct {
 }
 
 func registerKubeFlags(flags *pflag.FlagSet, cfg *kubeConfig) {
+	flags.StringVar(&cfg.Image, "kubernetes-job-image", cfg.Image, "Image to use for kubernetes jobs.")
 	flags.DurationVar(&cfg.TTLAfterFinish, "kubernetes-ttl-after-finish", cfg.TTLAfterFinish, "Delete finished kubernetes job after this duration.")
 	flags.StringVar(&cfg.flags.RequestCPU, "kubernetes-request-cpu", cfg.flags.RequestCPU, "Requested CPU for kubernetes job.")
 	flags.StringVar(&cfg.flags.RequestMemory, "kubernetes-request-memory", cfg.flags.RequestMemory, "Requested memory for kubernetes job.")
 	flags.StringVar(&cfg.flags.LimitCPU, "kubernetes-limit-cpu", cfg.flags.LimitCPU, "CPU limit for kubernetes job.")
 	flags.StringVar(&cfg.flags.LimitMemory, "kubernetes-limit-memory", cfg.flags.LimitMemory, "Memory limit for kubernetes job.")
 	flags.StringSliceVar(&cfg.flags.Labels, "kubernetes-labels", cfg.flags.Labels, "Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`.")
-
 }
 
 type kubeExecutor struct {


### PR DESCRIPTION
Proposed solution for #921.

Adds a --kubernetes-job-image flag (env var: OTF_KUBERNETES_JOB_IMAGE) that allows specifying a custom image for kubernetes jobs.