### PR TITLE
feat: Add compatibility for TFC environment variables.

### DIFF
--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -257,6 +257,33 @@ func (o *operation) do() error {
 		}
 	}()
 	o.workdir = wd
+
+	// Set TFC-compatible built-in environment variables.
+	// TFC_* variants are plain env vars; TF_VAR_* variants make them
+	// available as Terraform input variables (if declared).
+	//
+	// Documented here:
+	// https://developer.hashicorp.com/terraform/cloud-docs/workspaces/run/run-environment#environment-variables
+	o.envs = append(o.envs,
+		"TFC_RUN_ID="+o.run.ID.String(),
+		"TFC_WORKSPACE_NAME="+o.ws.Name,
+		"TFC_WORKSPACE_ID="+o.ws.ID.String(),
+		"TF_VAR_TFC_RUN_ID="+o.run.ID.String(),
+		"TF_VAR_TFC_WORKSPACE_NAME="+o.ws.Name,
+		"TF_VAR_TFC_WORKSPACE_ID="+o.ws.ID.String(),
+		"TFC_WORKSPACE_SLUG="+o.ws.Organization.String()+"/"+o.ws.Name,
+		"TF_VAR_TFC_WORKSPACE_SLUG="+o.ws.Organization.String()+"/"+o.ws.Name,
+	)
+	if o.run.IngressAttributes != nil {
+		ia := o.run.IngressAttributes
+		o.envs = append(o.envs,
+			"TFC_CONFIGURATION_VERSION_GIT_BRANCH="+ia.Branch,
+			"TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA="+ia.CommitSHA,
+			"TF_VAR_TFC_CONFIGURATION_VERSION_GIT_BRANCH="+ia.Branch,
+			"TF_VAR_TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA="+ia.CommitSHA,
+		)
+	}
+
 	writer := runpkg.NewPhaseWriter(o.ctx, runpkg.PhaseWriterOptions{
 		RunID:  run.ID,
 		Phase:  run.Phase(),


### PR DESCRIPTION
## Description

Terraform Enterprise provides [environment variables](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/run/run-environment#environment-variables) to runs that pass run and workspace identifiers. These are available as both environment variables and as regular variables (if defined).

This PR implements backwards-compatible variables where available.

## Use case

- Audit and traceability: tagging deployed resources with run ID and commit so you can trace any infrastructure resource back to the exact run and commit that created it.
- Conditional logic: branching Terraform behavior based on workspace name or git branch
- Environment-aware configuration: using workspace identity variables to dynamically derive environment-specific values like DNS domains or service URLs without hardcoding them per workspace (e.g. "${var.TFC_WORKSPACE_NAME}.example.com".
- TFE migration compatibility: existing Terraform configurations that reference these variables work out of the box when moving from Terraform Enterprise/Cloud to OTF

## Proposed solution

Create and append the variables at job execution time. Create both regular environment variable and TF_VAR_* variants to match TFC/TFE support.