### PR TITLE
fix: cross-platform build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # STAGE: base
 # This stage contains the files/packages that are used by the final images.
-FROM alpine:3.23.3 AS base
+FROM --platform=$BUILDPLATFORM alpine:3.23.3 AS base
 
 # Build cache optimization: use cache mounts
 # https://docs.docker.com/build/cache/optimize/#use-cache-mounts Mounting

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # STAGE: base
 # This stage contains the files/packages that are used by the final images.
-FROM --platform=$BUILDPLATFORM alpine:3.23.3 AS base
+FROM alpine:3.23.3 AS base
 
 # Build cache optimization: use cache mounts
 # https://docs.docker.com/build/cache/optimize/#use-cache-mounts Mounting

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 LD_FLAGS = '-s -w -X github.com/leg100/otf/internal.Version=edge'
-GOOS ?= linux
-GOARCH ?= amd64
-PLATFORM = $(GOOS)/$(GOARCH)
+GOARCH ?= $(shell go env GOARCH)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -20,9 +18,9 @@ test:
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+	GOOS=linux GOARCH=$(GOARCH) go build \
 		-ldflags $(LD_FLAGS) \
-		-o ./_build/$(GOOS)/$(GOARCH)/ \
+		-o ./_build/linux/$(GOARCH)/ \
 		./cmd/otfd ./cmd/otf-job ./cmd/otf-agent
 
 .PHONY: install
@@ -77,15 +75,15 @@ images: build
 
 .PHONY: image-otfd
 image-otfd: build
-	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otfd:edge --target otfd _build/
+	docker build -f Dockerfile -t leg100/otfd:edge --target otfd _build/
 
 .PHONY: image-agent
 image-agent: build
-	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otf-agent:edge --target otf-agent _build/
+	docker build -f Dockerfile -t leg100/otf-agent:edge --target otf-agent _build/
 
 .PHONY: image-job
 image-job: build
-	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otf-job:edge --target otf-job _build/
+	docker build -f Dockerfile -t leg100/otf-job:edge --target otf-job _build/
 
 # Build and load edge images into kubernetes kind
 .PHONY: load

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 LD_FLAGS = '-s -w -X github.com/leg100/otf/internal.Version=edge'
+GOOS ?= linux
 GOARCH ?= $(shell go env GOARCH)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -18,9 +19,9 @@ test:
 
 .PHONY: build
 build:
-	GOOS=linux GOARCH=$(GOARCH) go build \
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags $(LD_FLAGS) \
-		-o ./_build/linux/$(GOARCH)/ \
+		-o ./_build/$(GOOS)/$(GOARCH)/ \
 		./cmd/otfd ./cmd/otf-job ./cmd/otf-agent
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 LD_FLAGS = '-s -w -X github.com/leg100/otf/internal.Version=edge'
 GOOS ?= linux
 GOARCH ?= $(shell go env GOARCH)
+PLATFORM = $(GOOS)/$(GOARCH)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -76,15 +77,15 @@ images: build
 
 .PHONY: image-otfd
 image-otfd: build
-	docker build -f Dockerfile -t leg100/otfd:edge --target otfd _build/
+	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otfd:edge --target otfd _build/
 
 .PHONY: image-agent
 image-agent: build
-	docker build -f Dockerfile -t leg100/otf-agent:edge --target otf-agent _build/
+	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otf-agent:edge --target otf-agent _build/
 
 .PHONY: image-job
 image-job: build
-	docker build -f Dockerfile -t leg100/otf-job:edge --target otf-job _build/
+	docker build -f Dockerfile --platform $(PLATFORM) -t leg100/otf-job:edge --target otf-job _build/
 
 # Build and load edge images into kubernetes kind
 .PHONY: load


### PR DESCRIPTION
In recent change in #928, it updated the configuration to support building on arm devices, however by default forces the image to build as amd64 requiring emulation.

#928 provided images requiring emulation:
<img width="507" height="45" alt="image" src="https://github.com/user-attachments/assets/71d1a682-3333-4c43-9ca6-eaa6636aec27" />

This proposed change relies on the configured architecture in the Go toolchain instead. It also moves to hardcode GOOS to linux as it should always be linux to support alpine builds. Further, it removes the --platform setting in the Makefile reverting back to the $BUILDPLATFORM usage in the Dockerfile to ensure CI builds use the appropriate platform.

After proposed change, images running on arm appropriately:
<img width="542" height="43" alt="image" src="https://github.com/user-attachments/assets/c20e7402-b283-4131-bebd-06d37e07c39e" />
