### PR TITLE
fix: add support for GitHub annotated tags

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -259,12 +259,26 @@ func (g *Client) ListTags(ctx context.Context, opts vcs.ListTagsOptions) ([]stri
 }
 
 // resolveTagRef takes a ref of the form "tags/<name>" and returns the commit
-// SHA the tag points at. Lightweight tags point directly at a commit;
-// annotated/signed tags point at a tag object that in turn points at a
-// commit (see https://git-scm.com/book/en/v2/Git-Basics-Tagging), and must
-// be peeled. If the remote does not return git-object metadata for the ref
-// (e.g. a test fake) the input ref is returned unchanged so callers can fall
-// back to letting Github resolve it server-side.
+// SHA the tag points at, peeling annotated tag objects as needed.
+//
+// Lightweight tags point directly at a commit: the ref's object SHA is the
+// commit SHA. Annotated and signed tags point at a tag *object* (a distinct
+// git object kind) whose SHA is unrelated to the commit; the tag object must
+// be fetched and its `object` followed to reach the commit. This is the http
+// equivalent of `git rev-parse refs/tags/<name>^{commit}`. See:
+//
+//   - https://git-scm.com/book/en/v2/Git-Basics-Tagging
+//     (annotated vs lightweight tags, signed tags)
+//   - https://git-scm.com/docs/gitrevisions
+//     ("<rev>^{<type>}" peeling syntax)
+//   - https://docs.github.com/en/rest/git/refs#list-matching-references
+//     (object.type field on a ref: "commit" or "tag")
+//   - https://docs.github.com/en/rest/git/tags#get-a-tag
+//     (response shape with the underlying object the tag points at)
+//
+// If the remote does not return git-object metadata for the ref (e.g. a
+// test fake) the input ref is returned unchanged so callers can fall back
+// to letting Github resolve it server-side.
 func (g *Client) resolveTagRef(ctx context.Context, repo vcs.Repo, tagRef string) (string, error) {
 	refs, _, err := g.client.Git.ListMatchingRefs(ctx, repo.Owner(), repo.Name(), &github.ReferenceListOptions{
 		Ref: tagRef,
@@ -304,11 +318,14 @@ func (g *Client) GetRepoTarball(ctx context.Context, opts vcs.GetRepoTarballOpti
 	var gopts github.RepositoryContentGetOptions
 	if opts.Ref != nil {
 		ref := *opts.Ref
-		// Annotated (and signed) tags point at a tag object rather than a
-		// commit, and Github's archive endpoint does not reliably dereference
-		// them when given a "tags/<name>" ref. Peel any tag ref to its
-		// underlying commit SHA so that annotated and lightweight tags
-		// behave identically.
+		// Github's archive endpoint accepts a "commit-ish" ref, but its
+		// behaviour for annotated/signed tags - which are tag objects, not
+		// commits - is undocumented and observably unreliable in the wild.
+		// Peel every tag ref to its commit SHA up front so the endpoint is
+		// always handed a commit and resolution is identical for lightweight,
+		// annotated, and signed tags.
+		//   https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-tar
+		//   https://git-scm.com/book/en/v2/Git-Basics-Tagging
 		if strings.HasPrefix(ref, "tags/") {
 			resolved, err := g.resolveTagRef(ctx, opts.Repo, ref)
 			if err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -258,6 +258,40 @@ func (g *Client) ListTags(ctx context.Context, opts vcs.ListTagsOptions) ([]stri
 	return tags, nil
 }
 
+// resolveTagRef takes a ref of the form "tags/<name>" and returns the commit
+// SHA the tag points at. Lightweight tags point directly at a commit;
+// annotated/signed tags point at a tag object that in turn points at a
+// commit (see https://git-scm.com/book/en/v2/Git-Basics-Tagging), and must
+// be peeled. If the remote does not return git-object metadata for the ref
+// (e.g. a test fake) the input ref is returned unchanged so callers can fall
+// back to letting Github resolve it server-side.
+func (g *Client) resolveTagRef(ctx context.Context, repo vcs.Repo, tagRef string) (string, error) {
+	refs, _, err := g.client.Git.ListMatchingRefs(ctx, repo.Owner(), repo.Name(), &github.ReferenceListOptions{
+		Ref: tagRef,
+	})
+	if err != nil {
+		return "", err
+	}
+	for _, ref := range refs {
+		if strings.TrimPrefix(ref.GetRef(), "refs/") != tagRef {
+			continue
+		}
+		obj := ref.GetObject()
+		switch obj.GetType() {
+		case "commit":
+			return obj.GetSHA(), nil
+		case "tag":
+			tag, _, err := g.client.Git.GetTag(ctx, repo.Owner(), repo.Name(), obj.GetSHA())
+			if err != nil {
+				return "", fmt.Errorf("dereferencing annotated tag object %s: %w", obj.GetSHA(), err)
+			}
+			return tag.GetObject().GetSHA(), nil
+		}
+		break
+	}
+	return tagRef, nil
+}
+
 func (g *Client) ExchangeCode(ctx context.Context, code string) (*github.AppConfig, error) {
 	cfg, _, err := g.client.Apps.CompleteAppManifest(ctx, code)
 	if err != nil {
@@ -269,7 +303,20 @@ func (g *Client) ExchangeCode(ctx context.Context, code string) (*github.AppConf
 func (g *Client) GetRepoTarball(ctx context.Context, opts vcs.GetRepoTarballOptions) ([]byte, string, error) {
 	var gopts github.RepositoryContentGetOptions
 	if opts.Ref != nil {
-		gopts.Ref = *opts.Ref
+		ref := *opts.Ref
+		// Annotated (and signed) tags point at a tag object rather than a
+		// commit, and Github's archive endpoint does not reliably dereference
+		// them when given a "tags/<name>" ref. Peel any tag ref to its
+		// underlying commit SHA so that annotated and lightweight tags
+		// behave identically.
+		if strings.HasPrefix(ref, "tags/") {
+			resolved, err := g.resolveTagRef(ctx, opts.Repo, ref)
+			if err != nil {
+				return nil, "", fmt.Errorf("resolving tag %s: %w", ref, err)
+			}
+			ref = resolved
+		}
+		gopts.Ref = ref
 	}
 
 	link, _, err := g.client.Repositories.GetArchiveLink(ctx, opts.Repo.Owner(), opts.Repo.Name(), github.Tarball, &gopts, maxRedirects)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -68,12 +68,27 @@ func TestGetRepoTarball(t *testing.T) {
 	assert.FileExists(t, path.Join(dst, "main.tf"))
 }
 
-// TestGetRepoTarball_AnnotatedTag verifies that when GetRepoTarball is
-// called with an annotated/signed tag ref, the tag is peeled to its
-// underlying commit SHA before the archive endpoint is hit. Without
-// peeling, Github's archive endpoint is handed a ref that points at the
-// tag object rather than a commit, which fails in the wild (see #911).
-func TestGetRepoTarball_AnnotatedTag(t *testing.T) {
+// TestGetRepoTarball_PeelsTagsToCommit verifies that GetRepoTarball
+// resolves tag refs to their underlying commit SHA before calling Github's
+// archive endpoint.
+//
+// Annotated and signed tags are tag *objects* whose SHA is distinct from
+// the commit they point at; Github's archive endpoint does not reliably
+// dereference them, which is the bug reported in #911. The lightweight
+// case is exercised alongside to prove the new code path is symmetric
+// (both tag flavours arrive at the archive endpoint as commit SHAs).
+//
+// Mocked responses follow the documented Github API shapes:
+//
+//   - List matching references:
+//     https://docs.github.com/en/rest/git/refs#list-matching-references
+//   - Get a tag (annotated tag dereferencing):
+//     https://docs.github.com/en/rest/git/tags#get-a-tag
+//
+// Background on lightweight vs annotated/signed tags:
+//
+//   - https://git-scm.com/book/en/v2/Git-Basics-Tagging
+func TestGetRepoTarball_PeelsTagsToCommit(t *testing.T) {
 	tarballBytes, err := os.ReadFile("../testdata/github.tar.gz")
 	require.NoError(t, err)
 
@@ -85,64 +100,109 @@ func TestGetRepoTarball_AnnotatedTag(t *testing.T) {
 		tagName   = "v1.0.0"
 	)
 
-	var capturedTarballRef string
+	for _, tc := range []struct {
+		name string
+		// refObjectType is what `object.type` is set to on the ref returned
+		// by Github's matching-refs endpoint: "commit" for a lightweight
+		// tag, "tag" for an annotated/signed tag.
+		refObjectType string
+		// refObjectSHA is the SHA returned alongside refObjectType.
+		// Lightweight tags point at a commit, so this is the commit SHA.
+		// Annotated tags point at a tag object, so this is the tag-object
+		// SHA, which then has to be peeled via /git/tags/{sha}.
+		refObjectSHA string
+		// wantGetTagCall is true when the implementation is expected to
+		// follow the annotated path and call Git.GetTag.
+		wantGetTagCall bool
+	}{
+		{
+			name:           "lightweight tag",
+			refObjectType:  "commit",
+			refObjectSHA:   commitSHA,
+			wantGetTagCall: false,
+		},
+		{
+			name:           "annotated tag",
+			refObjectType:  "tag",
+			refObjectSHA:   tagObjSHA,
+			wantGetTagCall: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				capturedTarballRef string
+				getTagCalled       bool
+			)
 
-	mux := http.NewServeMux()
-	// Github responds to ListMatchingRefs for an annotated tag with a ref
-	// whose object is itself a tag object (rather than a commit).
-	mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/matching-refs/tags/"+tagName, func(w http.ResponseWriter, r *http.Request) {
-		refs := []*github.Reference{{
-			Ref: new("refs/tags/" + tagName),
-			Object: &github.GitObject{
-				Type: new("tag"),
-				SHA:  new(tagObjSHA),
-			},
-		}}
-		require.NoError(t, json.NewEncoder(w).Encode(refs))
-	})
-	// Github exposes the underlying commit of an annotated tag via the
-	// tag-object endpoint.
-	mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/tags/"+tagObjSHA, func(w http.ResponseWriter, r *http.Request) {
-		tag := &github.Tag{
-			SHA: new(tagObjSHA),
-			Object: &github.GitObject{
-				Type: new("commit"),
-				SHA:  new(commitSHA),
-			},
-		}
-		require.NoError(t, json.NewEncoder(w).Encode(tag))
-	})
-	// Capture whatever ref the archive endpoint is called with, then serve
-	// up a real tarball so GetRepoTarball can complete.
-	tarballPrefix := "/api/v3/repos/" + owner + "/" + repoName + "/tarball/"
-	mux.HandleFunc(tarballPrefix, func(w http.ResponseWriter, r *http.Request) {
-		capturedTarballRef = strings.TrimPrefix(r.URL.Path, tarballPrefix)
-		http.Redirect(w, r, (&url.URL{Scheme: "https", Host: r.Host, Path: "/archive"}).String(), http.StatusFound)
-	})
-	mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) {
-		w.Write(tarballBytes)
-	})
+			mux := http.NewServeMux()
 
-	server := httptest.NewTLSServer(mux)
-	t.Cleanup(server.Close)
+			// matching-refs: shape per
+			// https://docs.github.com/en/rest/git/refs#list-matching-references
+			// For an annotated tag, object.type is "tag"; for a lightweight
+			// tag, object.type is "commit".
+			mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/matching-refs/tags/"+tagName, func(w http.ResponseWriter, r *http.Request) {
+				refs := []*github.Reference{{
+					Ref: new("refs/tags/" + tagName),
+					Object: &github.GitObject{
+						Type: new(tc.refObjectType),
+						SHA:  new(tc.refObjectSHA),
+					},
+				}}
+				require.NoError(t, json.NewEncoder(w).Encode(refs))
+			})
 
-	u, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	client, err := NewClient(ClientOptions{
-		BaseURL:             &internal.WebURL{URL: *u},
-		SkipTLSVerification: true,
-		OAuthToken:          &oauth2.Token{AccessToken: "fake-token"},
-	})
-	require.NoError(t, err)
+			// get-a-tag: shape per
+			// https://docs.github.com/en/rest/git/tags#get-a-tag
+			// The tag object's `object` field is the commit it annotates.
+			// This handler is only expected to be hit for the annotated case.
+			mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/tags/"+tagObjSHA, func(w http.ResponseWriter, r *http.Request) {
+				getTagCalled = true
+				tag := &github.Tag{
+					SHA: new(tagObjSHA),
+					Object: &github.GitObject{
+						Type: new("commit"),
+						SHA:  new(commitSHA),
+					},
+				}
+				require.NoError(t, json.NewEncoder(w).Encode(tag))
+			})
 
-	ref := "tags/" + tagName
-	_, _, err = client.GetRepoTarball(t.Context(), vcs.GetRepoTarballOptions{
-		Repo: vcs.NewMustRepo(owner, repoName),
-		Ref:  &ref,
-	})
-	require.NoError(t, err)
-	assert.Equal(t, commitSHA, capturedTarballRef,
-		"annotated tag must be peeled to its commit SHA before the archive endpoint is called")
+			// Archive endpoint: record the ref it was called with, then
+			// redirect to a static tarball so GetRepoTarball can complete.
+			tarballPrefix := "/api/v3/repos/" + owner + "/" + repoName + "/tarball/"
+			mux.HandleFunc(tarballPrefix, func(w http.ResponseWriter, r *http.Request) {
+				capturedTarballRef = strings.TrimPrefix(r.URL.Path, tarballPrefix)
+				http.Redirect(w, r, (&url.URL{Scheme: "https", Host: r.Host, Path: "/archive"}).String(), http.StatusFound)
+			})
+			mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) {
+				w.Write(tarballBytes)
+			})
+
+			server := httptest.NewTLSServer(mux)
+			t.Cleanup(server.Close)
+
+			u, err := url.Parse(server.URL)
+			require.NoError(t, err)
+			client, err := NewClient(ClientOptions{
+				BaseURL:             &internal.WebURL{URL: *u},
+				SkipTLSVerification: true,
+				OAuthToken:          &oauth2.Token{AccessToken: "fake-token"},
+			})
+			require.NoError(t, err)
+
+			ref := "tags/" + tagName
+			_, _, err = client.GetRepoTarball(t.Context(), vcs.GetRepoTarballOptions{
+				Repo: vcs.NewMustRepo(owner, repoName),
+				Ref:  &ref,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, commitSHA, capturedTarballRef,
+				"archive endpoint must be called with the peeled commit SHA")
+			assert.Equal(t, tc.wantGetTagCall, getTagCalled,
+				"Git.GetTag should only be called for annotated tags")
+		})
+	}
 }
 
 func TestCreateWebhook(t *testing.T) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -2,8 +2,13 @@ package github
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v65/github"
@@ -61,6 +66,83 @@ func TestGetRepoTarball(t *testing.T) {
 	err = internal.Unpack(bytes.NewReader(got), dst)
 	require.NoError(t, err)
 	assert.FileExists(t, path.Join(dst, "main.tf"))
+}
+
+// TestGetRepoTarball_AnnotatedTag verifies that when GetRepoTarball is
+// called with an annotated/signed tag ref, the tag is peeled to its
+// underlying commit SHA before the archive endpoint is hit. Without
+// peeling, Github's archive endpoint is handed a ref that points at the
+// tag object rather than a commit, which fails in the wild (see #911).
+func TestGetRepoTarball_AnnotatedTag(t *testing.T) {
+	tarballBytes, err := os.ReadFile("../testdata/github.tar.gz")
+	require.NoError(t, err)
+
+	const (
+		commitSHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		tagObjSHA = "abc123abc123abc123abc123abc123abc123abc1"
+		owner     = "acme"
+		repoName  = "terraform"
+		tagName   = "v1.0.0"
+	)
+
+	var capturedTarballRef string
+
+	mux := http.NewServeMux()
+	// Github responds to ListMatchingRefs for an annotated tag with a ref
+	// whose object is itself a tag object (rather than a commit).
+	mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/matching-refs/tags/"+tagName, func(w http.ResponseWriter, r *http.Request) {
+		refs := []*github.Reference{{
+			Ref: new("refs/tags/" + tagName),
+			Object: &github.GitObject{
+				Type: new("tag"),
+				SHA:  new(tagObjSHA),
+			},
+		}}
+		require.NoError(t, json.NewEncoder(w).Encode(refs))
+	})
+	// Github exposes the underlying commit of an annotated tag via the
+	// tag-object endpoint.
+	mux.HandleFunc("/api/v3/repos/"+owner+"/"+repoName+"/git/tags/"+tagObjSHA, func(w http.ResponseWriter, r *http.Request) {
+		tag := &github.Tag{
+			SHA: new(tagObjSHA),
+			Object: &github.GitObject{
+				Type: new("commit"),
+				SHA:  new(commitSHA),
+			},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(tag))
+	})
+	// Capture whatever ref the archive endpoint is called with, then serve
+	// up a real tarball so GetRepoTarball can complete.
+	tarballPrefix := "/api/v3/repos/" + owner + "/" + repoName + "/tarball/"
+	mux.HandleFunc(tarballPrefix, func(w http.ResponseWriter, r *http.Request) {
+		capturedTarballRef = strings.TrimPrefix(r.URL.Path, tarballPrefix)
+		http.Redirect(w, r, (&url.URL{Scheme: "https", Host: r.Host, Path: "/archive"}).String(), http.StatusFound)
+	})
+	mux.HandleFunc("/archive", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(tarballBytes)
+	})
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	client, err := NewClient(ClientOptions{
+		BaseURL:             &internal.WebURL{URL: *u},
+		SkipTLSVerification: true,
+		OAuthToken:          &oauth2.Token{AccessToken: "fake-token"},
+	})
+	require.NoError(t, err)
+
+	ref := "tags/" + tagName
+	_, _, err = client.GetRepoTarball(t.Context(), vcs.GetRepoTarballOptions{
+		Repo: vcs.NewMustRepo(owner, repoName),
+		Ref:  &ref,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, commitSHA, capturedTarballRef,
+		"annotated tag must be peeled to its commit SHA before the archive endpoint is called")
 }
 
 func TestCreateWebhook(t *testing.T) {


### PR DESCRIPTION
This addresses #911 which I created. I tried to add explanation links/docs in the test mocks to demonstrate the problem

FWIW, from our own real deployment of OTF, we got this error today (from the same issue - a non-lightweight git tag that's unretrievable by OTF):
```
{"time":"2026-05-25T15:16:12.721288605Z","level":"ERROR","msg":"handling event","component":"publisher","sha":"58659e830f0ca0675b0acf28d463029924219376","type":"tag","action":"created","branch":"","tag":"v0.0.1","repo":"Optable/xxx","error":"retrieving module: resource not found"}
```
When we deleted the tag (signed/annotated) and recreated it as a simple lightweight tag, that worked (that was our old workaround).

With this PR, we should be able to use any kind of tag.