### PR TITLE
fix(otf-agent): correct indent on .Values.volumes and .Values.volumeMounts

### DIFF
--- a/charts/otf-agent/templates/deployment.yaml
+++ b/charts/otf-agent/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           emptyDir: {}
         {{- include "runner.volume" . | nindent 8 }}
         {{- with .Values.volumes }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
         {{- with .Values.sidecars }}
@@ -83,7 +83,7 @@ spec:
           volumeMounts:
           {{- include "runner.volume_mounts" . | nindent 10 }}
           {{- with .Values.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/otf-agent/tests/volume_mounts.yaml
+++ b/charts/otf-agent/tests/volume_mounts.yaml
@@ -1,0 +1,14 @@
+volumes:
+  - name: otf-keys
+    secret:
+      secretName: otfd
+      items:
+        - key: public_key
+          path: public_key
+        - key: private_key
+          path: private_key
+
+volumeMounts:
+  - name: otf-keys
+    mountPath: /etc/otf/keys
+    readOnly: true

--- a/hack/helm-lint.sh
+++ b/hack/helm-lint.sh
@@ -1,5 +1,6 @@
 helm lint ./charts/otfd
 helm lint ./charts/otf-agent
+helm lint ./charts/otf-agent --values ./charts/otf-agent/tests/volume_mounts.yaml
 helm template ./charts/otfd > /dev/null
 helm template ./charts/otfd --values ./charts/otfd/tests/volume_mounts.yaml > /dev/null
 helm template ./charts/otf-agent --set token=my_agent_token --set url=https://otf.ninja > /dev/null


### PR DESCRIPTION
Both used `nindent` values one level too deep relative to the surrounding list items (10 vs 8 for volumes, 12 vs 10 for volumeMounts). User-supplied entries rendered as a nested continuation of the previous item instead of as a sibling list item, producing invalid YAML.