### PR TITLE
fix: add startupProbe and enable probes to be configurable

### DIFF
--- a/charts/otfd/Chart.yaml
+++ b/charts/otfd/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.35
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/otfd/README.md
+++ b/charts/otfd/README.md
@@ -67,7 +67,7 @@ Note: you should only use this for testing purposes.
 | ingress.path | string | `"/"` |  |
 | ingress.pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
-| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Liveness probe for the otfd container. Set to `{}` to disable. See [k8s probe docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes). |
+| livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/healthz","port":"http"}}` | Liveness probe for the otfd container. Set to `{}` to disable. See [k8s probe docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes). |
 | logging.format | string | `"default"` | Logging format: default, text, or json. See [docs](https://docs.otf.ninja/config/flags/#-log-format) |
 | logging.http | bool | `false` | Log http requests. |
 | logging.verbosity | int | `0` | Logging verbosity, the higher the number the more verbose the logs. See [docs](https://docs.otf.ninja/config/flags/#-v). |
@@ -101,7 +101,7 @@ Note: you should only use this for testing purposes.
 | sidecars | list | `[]` | Additional sidecar containers to run alongside the main otfd container |
 | siteAdmins | list | `[]` | Site admins - list of user accounts promoted to site admin. See [docs](https://docs.otf.ninja/config/flags/#-site-admins). |
 | siteToken | string | `""` | Site admin token - empty string disables the site admin account. See [docs](https://docs.otf.ninja/config/flags/#-site-token). |
-| startupProbe | object | `{}` | Startup probe for the otfd container. Disabled by default; uncomment the spec below to enable. |
+| startupProbe | object | `{"failureThreshold":120,"httpGet":{"path":"/healthz","port":"http"},"periodSeconds":1}` | Startup probe for the otfd container. Set to `{}` to disable. |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` | Additional volume mounts for the main otfd container |
 | volumes | list | `[]` | Additional volumes to make available to the pod |

--- a/charts/otfd/README.md
+++ b/charts/otfd/README.md
@@ -1,6 +1,6 @@
 # Helm chart for `otfd`
 
-![Version: 0.3.35](https://img.shields.io/badge/Version-0.3.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
 Installs the [otf](https://github.com/leg100/otf) daemon.
 
@@ -67,6 +67,7 @@ Note: you should only use this for testing purposes.
 | ingress.path | string | `"/"` |  |
 | ingress.pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Liveness probe for the otfd container. Set to `{}` to disable. See [k8s probe docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes). |
 | logging.format | string | `"default"` | Logging format: default, text, or json. See [docs](https://docs.otf.ninja/config/flags/#-log-format) |
 | logging.http | bool | `false` | Log http requests. |
 | logging.verbosity | int | `0` | Logging verbosity, the higher the number the more verbose the logs. See [docs](https://docs.otf.ninja/config/flags/#-v). |
@@ -85,6 +86,7 @@ Note: you should only use this for testing purposes.
 | postgres.enabled | bool | `false` | Install postgres chart dependency. NOTE: this should only be used for testing purposes. |
 | proxy | string | `nil` | Specify an http(s) proxy for outbound connections. |
 | rbac.create | bool | `true` | Create and use RBAC resources |
+| readinessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Readiness probe for the otfd container. Set to `{}` to disable. |
 | replicaCount | int | `1` | Number of otfd nodes to cluster |
 | resources | object | `{}` |  |
 | secret | string | `""` | Cryptographic secret. Must be a hex-encoded 16-byte string. See [docs](https://docs.otf.ninja/config/flags/#-secret). |
@@ -99,6 +101,7 @@ Note: you should only use this for testing purposes.
 | sidecars | list | `[]` | Additional sidecar containers to run alongside the main otfd container |
 | siteAdmins | list | `[]` | Site admins - list of user accounts promoted to site admin. See [docs](https://docs.otf.ninja/config/flags/#-site-admins). |
 | siteToken | string | `""` | Site admin token - empty string disables the site admin account. See [docs](https://docs.otf.ninja/config/flags/#-site-token). |
+| startupProbe | object | `{}` | Startup probe for the otfd container. Disabled by default; uncomment the spec below to enable. |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` | Additional volume mounts for the main otfd container |
 | volumes | list | `[]` | Additional volumes to make available to the pod |

--- a/charts/otfd/templates/deployment.yaml
+++ b/charts/otfd/templates/deployment.yaml
@@ -171,14 +171,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/otfd/values.yaml
+++ b/charts/otfd/values.yaml
@@ -184,6 +184,24 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Liveness probe for the otfd container. Set to `{}` to disable. See [k8s probe docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# -- Readiness probe for the otfd container. Set to `{}` to disable.
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# -- Startup probe for the otfd container. Disabled by default; uncomment the spec below to enable.
+startupProbe: {}
+  # httpGet:
+  #   path: /healthz
+  #   port: http
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/otfd/values.yaml
+++ b/charts/otfd/values.yaml
@@ -184,8 +184,25 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# -- Liveness probe for the otfd container. Set to `{}` to disable. See [k8s probe docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
+# -- Startup probe for the otfd container. Set to `{}` to disable.
+startupProbe:
+  # Allow enough time for database migrations to complete. With large
+  # installations these can take a long while so allow 120 seconds before
+  # deeming startup a failure.
+  periodSeconds: 1
+  failureThreshold: 120
+  httpGet:
+    path: /healthz
+    port: http
+
+# -- Liveness probe for the otfd container. Set to `{}` to disable. See [k8s
+# probe
+# docs](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes).
 livenessProbe:
+  # Set a higher failure threshold (5) than that for the readiness probe (3),
+  # ensuring the pod is observed as not-ready for some period of time before it
+  # is hard killed.
+  failureThreshold: 5
   httpGet:
     path: /healthz
     port: http
@@ -195,12 +212,6 @@ readinessProbe:
   httpGet:
     path: /healthz
     port: http
-
-# -- Startup probe for the otfd container. Disabled by default; uncomment the spec below to enable.
-startupProbe: {}
-  # httpGet:
-  #   path: /healthz
-  #   port: http
 
 nodeSelector: {}
 

--- a/internal/sql/migrations.go
+++ b/internal/sql/migrations.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/leg100/otf/internal/logr"
 	"github.com/jackc/pgx/v5"
 	tern "github.com/jackc/tern/v2/migrate"
+	"github.com/leg100/otf/internal/logr"
 )
 
 //go:embed migrations/*.sql
@@ -34,7 +34,10 @@ func migrate(ctx context.Context, logger logr.Logger, connString string) error {
 	}
 	from, err := m.GetCurrentVersion(ctx)
 	if err != nil {
-		return fmt.Errorf("retreiving current database migration version")
+		return fmt.Errorf("retrieving current database migration version")
+	}
+	if from != int32(len(m.Migrations)) {
+		logger.Info("migrating database schema", "from", from, "to", len(m.Migrations))
 	}
 	if err := m.Migrate(ctx); err != nil {
 		return err
@@ -42,7 +45,7 @@ func migrate(ctx context.Context, logger logr.Logger, connString string) error {
 	if from == int32(len(m.Migrations)) {
 		logger.Info("database schema up to date", "version", len(m.Migrations))
 	} else {
-		logger.Info("migrated database schema", "from", from, "to", len(m.Migrations))
+		logger.Info("completed database migration", "from", from, "to", len(m.Migrations))
 	}
 	return nil
 }


### PR DESCRIPTION
This aims to allow users to configure startupProbe to allow longer migration to complete #958 

* Allowed configurable otfd liveness + readiness probes.
* Added option to enable a otfd startupProbe.