### PR TITLE
fix(k8s): service account permission issue when listing jobs

### DIFF
--- a/charts/libs/runner/templates/_role.yaml
+++ b/charts/libs/runner/templates/_role.yaml
@@ -13,6 +13,7 @@ rules:
     - jobs
   verbs:
     - create
+    - list
 - apiGroups:
     - "" # core API group
   resources:


### PR DESCRIPTION
The service account created for kubernetes executor is missing the `list` verb for jobs.

When running on a talos cluster list permission must be explicitely granted to avoid errors.

```
ERROR listing current number of kubernetes jobs error="jobs.batch is forbidden: User \"system:serviceaccount:otf:otf-otfd\" cannot list resource \"jobs\" in API group \"batch\" in the namespace \"otf\""
```