### PR TITLE
fix(ci): restore otf cli to releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,22 @@ builds:
     goarch:
     - amd64
     - arm64
+  - id: otf
+    ldflags:
+    - -s -w
+    - -X github.com/leg100/otf/internal.Version={{.Version}}
+    - -X github.com/leg100/otf/internal.Commit={{.Commit}}
+    - -X github.com/leg100/otf/internal.Built={{.Date}}
+    main: ./cmd/otf
+    binary: otf
+    env:
+      - CGO_ENABLED=0
+    goos:
+    - darwin
+    - linux
+    goarch:
+    - amd64
+    - arm64
 archives:
 - id: otfd
   ids: [otfd]
@@ -59,6 +75,10 @@ archives:
   ids: [otf-job]
   formats: [zip]
   name_template: "otf-job_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+- id: otf
+  ids: [otf]
+  formats: [zip]
+  name_template: "otf_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 dockers_v2:
 - id: otfd
   ids: [otfd]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags $(LD_FLAGS) \
 		-o ./_build/$(GOOS)/$(GOARCH)/ \
-		./cmd/otfd ./cmd/otf-job ./cmd/otf-agent
+		./cmd/otfd ./cmd/otf-job ./cmd/otf-agent ./cmd/otf
 
 .PHONY: install
 install:


### PR DESCRIPTION
## What

Restore the `otf` client CLI to the release pipeline.

- Add the `otf` build + archive entries to `.goreleaser.yml` (darwin + linux, amd64 + arm64), producing the `otf_<version>_<os>_<arch>.zip` asset.
- Add `./cmd/otf` to the Makefile `build` target.

No Docker image — `otf` is a downloadable client, not a daemon.

## Why

The `otf` CLI was accidentally dropped from releases in 64716f9b ("fix(ci): broke release process"). That commit migrated goreleaser to v2 and introduced `otf-job`, but instead of adding a new build entry it repurposed the existing `otf` build/archive slot:

```diff
-  - id: otf
+  - id: otf-job
-    main: ./cmd/otf
+    main: ./cmd/otf-job
```

As a result, GitHub releases no longer ship the `otf` binary, even though `docs/docs/cli.md` still instructs users to download it. There is no documented decision to retire the CLI — it was collateral damage during the otf-job rollout.

## Verification

- `make build` now emits `otfd`, `otf-agent`, `otf-job`, and `otf`.
- `.goreleaser.yml` is valid YAML and mirrors the existing `otf-job` entry (please confirm `goreleaser check` passes in CI).