### PR TITLE
feat: Add support for imagePullSecrets for kubernetes jobs.

### DIFF
--- a/charts/libs/runner/README.md
+++ b/charts/libs/runner/README.md
@@ -14,6 +14,7 @@ A Helm chart library for otf runner resources and configuration.
 | cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| kubernetesImagePullSecrets | list | `[]` | Names of secrets in the same namespace to use for pulling the kubernetes job image from a private registry, e.g. `["my-registry-creds"]`. |
 | kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |

--- a/charts/libs/runner/templates/_envs.yaml
+++ b/charts/libs/runner/templates/_envs.yaml
@@ -36,6 +36,10 @@
 - name: OTF_KUBERNETES_JOB_IMAGE
   value: "{{ . }}"
 {{- end }}
+{{- with .kubernetesImagePullSecrets }}
+- name: OTF_KUBERNETES_IMAGE_PULL_SECRETS
+  value: {{ . | join "," }}
+{{- end }}
 - name: OTF_ENGINE_BINS_DIR
   value: "/cache/engines"
 {{- with .pluginCache }}

--- a/charts/libs/runner/values.yaml
+++ b/charts/libs/runner/values.yaml
@@ -14,6 +14,8 @@ kubernetesLimitMemory: ~
 kubernetesLabels: []
 # -- Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image).
 kubernetesJobImage: ""
+# -- Names of secrets in the same namespace to use for pulling the kubernetes job image from a private registry, e.g. `["my-registry-creds"]`.
+kubernetesImagePullSecrets: []
 # -- Delete finished kubernetes jobs after this duration.
 kubernetesTTLAfterFinish:
 # -- (bool) Enable shared provider plugin cache for terraform providers. Note this is only concurrency safe in opentofu 1.10.0 and greater.

--- a/charts/otf-agent/README.md
+++ b/charts/otf-agent/README.md
@@ -89,6 +89,7 @@ address=10.244.0.18 agent.pool_id=apool-5b90443ed82ef769
 | runner.cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | runner.concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | runner.executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| runner.kubernetesImagePullSecrets | list | `[]` | Names of secrets in the same namespace to use for pulling the kubernetes job image from a private registry, e.g. `["my-registry-creds"]`. |
 | runner.kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | runner.kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | runner.kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |

--- a/charts/otfd/README.md
+++ b/charts/otfd/README.md
@@ -111,6 +111,7 @@ Note: you should only use this for testing purposes.
 | runner.cacheVolume.storageClass | string | `nil` | Persistent volume storage class. # If defined, storageClassName: <storageClass> # If set to "-", storageClassName: "", which disables dynamic provisioning # If undefined (the default) or set to null, no storageClassName spec is # set, choosing the default provisioner. |
 | runner.concurrency | int | `nil` | Set the number of runs that can be processed concurrently. See [docs](https://docs.otf.ninja/config/flags/#-concurrency). |
 | runner.executor | string | `""` | The executor to use. See [docs](https://docs.otf.ninja/config/flags/#-executor) |
+| runner.kubernetesImagePullSecrets | list | `[]` | Names of secrets in the same namespace to use for pulling the kubernetes job image from a private registry, e.g. `["my-registry-creds"]`. |
 | runner.kubernetesJobImage | string | `""` | Set the kubernetes job image. Defaults to `leg100/otf-job` tagged with the current OTF version. See [docs](https://docs.otf.ninja/config/flags/#-kubernetes-job-image). |
 | runner.kubernetesLabels | list | `[]` | Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`. |
 | runner.kubernetesLimitCPU | string | `nil` | Set a CPU limit for kubernetes jobs. |

--- a/docs/docs/config/flags.md
+++ b/docs/docs/config/flags.md
@@ -135,6 +135,15 @@ It is advisable to set this flag in a production deployment. Otherwise it defaul
 
 Set the image used for kubernetes jobs. Allows customization of the job image so that you can add custom tools or logic to your run environments.
 
+## `--kubernetes-image-pull-secrets`
+
+* System: `otfd`, `otf-agent`
+* Default: `""`
+
+Names of secrets to use for pulling the kubernetes job image from a private registry, e.g. `my-registry-creds`. Specify multiple names separated by a comma. Each secret must be of type `kubernetes.io/dockerconfigjson` and must exist in the same namespace as the jobs.
+
+Note this is separate to any image pull secrets set on the `otfd` or `otf-agent` deployment itself; those are not inherited by jobs.
+
 ## `--kubernetes-request-cpu`
 
 * System: `otfd`, `otf-agent`

--- a/docs/docs/executors.md
+++ b/docs/docs/executors.md
@@ -26,6 +26,7 @@ This executor is only functional when `otfd` or `otf-agent` is deployed via the 
 There are a number of flags that customise the jobs:
 
 * [`--kubernetes-job-image`](config/flags.md#-kubernetes-job-image)
+* [`--kubernetes-image-pull-secrets`](config/flags.md#-kubernetes-image-pull-secrets)
 * [`--kubernetes-request-cpu`](config/flags.md#-kubernetes-request-cpu)
 * [`--kubernetes-request-memory`](config/flags.md#-kubernetes-request-memory)
 * [`--kubernetes-ttl-after-finish`](config/flags.md#-kubernetes-ttl-after-finish)

--- a/internal/runner/executor_kube.go
+++ b/internal/runner/executor_kube.go
@@ -82,11 +82,12 @@ type kubeConfig struct {
 	CachePVC       string
 	TTLAfterFinish time.Duration
 
-	requestCPU    k8sresource.Quantity
-	requestMemory k8sresource.Quantity
-	limitCPU      *k8sresource.Quantity
-	limitMemory   *k8sresource.Quantity
-	labels        map[string]string
+	requestCPU       k8sresource.Quantity
+	requestMemory    k8sresource.Quantity
+	limitCPU         *k8sresource.Quantity
+	limitMemory      *k8sresource.Quantity
+	labels           map[string]string
+	imagePullSecrets []corev1.LocalObjectReference
 
 	flags kubeConfigFlags
 }
@@ -94,11 +95,12 @@ type kubeConfig struct {
 // kubeConfigFlags are CLI flags that need to be parsed first and should not be
 // used directly by the kubernetes executor.
 type kubeConfigFlags struct {
-	Labels        []string
-	RequestCPU    string
-	RequestMemory string
-	LimitCPU      string
-	LimitMemory   string
+	Labels           []string
+	RequestCPU       string
+	RequestMemory    string
+	LimitCPU         string
+	LimitMemory      string
+	ImagePullSecrets []string
 }
 
 func registerKubeFlags(flags *pflag.FlagSet, cfg *kubeConfig) {
@@ -109,6 +111,7 @@ func registerKubeFlags(flags *pflag.FlagSet, cfg *kubeConfig) {
 	flags.StringVar(&cfg.flags.LimitCPU, "kubernetes-limit-cpu", cfg.flags.LimitCPU, "CPU limit for kubernetes job.")
 	flags.StringVar(&cfg.flags.LimitMemory, "kubernetes-limit-memory", cfg.flags.LimitMemory, "Memory limit for kubernetes job.")
 	flags.StringSliceVar(&cfg.flags.Labels, "kubernetes-labels", cfg.flags.Labels, "Set additional labels on kubernetes jobs. Name and value are separated by an equals sign, e.g. `foo=bar`.")
+	flags.StringSliceVar(&cfg.flags.ImagePullSecrets, "kubernetes-image-pull-secrets", cfg.flags.ImagePullSecrets, "Names of secrets in the same namespace to use for pulling the kubernetes job image from a private registry.")
 }
 
 type kubeExecutor struct {
@@ -175,6 +178,15 @@ func newKubeExecutor(
 			return nil, fmt.Errorf("invalid label: must be in format name=value")
 		}
 		executor.Config.labels[k] = v
+	}
+
+	for _, name := range kubeConfig.flags.ImagePullSecrets {
+		if name == "" {
+			return nil, fmt.Errorf("invalid image pull secret: name cannot be empty")
+		}
+		executor.Config.imagePullSecrets = append(executor.Config.imagePullSecrets, corev1.LocalObjectReference{
+			Name: name,
+		})
 	}
 
 	// assume running in-cluster; otherwise use config path
@@ -265,6 +277,7 @@ func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, jo
 				Spec: corev1.PodSpec{
 					ServiceAccountName: s.Config.ServiceAccount,
 					RestartPolicy:      corev1.RestartPolicyNever,
+					ImagePullSecrets:   s.Config.imagePullSecrets,
 					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    s.Config.requestCPU,

--- a/internal/runner/executor_kube_test.go
+++ b/internal/runner/executor_kube_test.go
@@ -74,6 +74,34 @@ func TestNewKubeExecutor(t *testing.T) {
 		)
 		assert.Error(t, err)
 	})
+
+	t.Run("with image pull secrets", func(t *testing.T) {
+		cfg := defaultKubeConfig
+		cfg.flags.ImagePullSecrets = []string{"regcred", "othercred"}
+
+		executor, err := newKubeExecutor(
+			logr.Discard(),
+			defaultOperationConfig(),
+			cfg,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []corev1.LocalObjectReference{
+			{Name: "regcred"},
+			{Name: "othercred"},
+		}, executor.Config.imagePullSecrets)
+	})
+
+	t.Run("with invalid image pull secrets", func(t *testing.T) {
+		cfg := defaultKubeConfig
+		cfg.flags.ImagePullSecrets = []string{""}
+
+		_, err := newKubeExecutor(
+			logr.Discard(),
+			defaultOperationConfig(),
+			cfg,
+		)
+		assert.Error(t, err)
+	})
 }
 
 func TestKubeExecutor_SpawnOperation(t *testing.T) {
@@ -81,6 +109,7 @@ func TestKubeExecutor_SpawnOperation(t *testing.T) {
 	cfg.flags.Labels = []string{"foo=bar"}
 	cfg.flags.LimitCPU = "3000m"
 	cfg.flags.LimitMemory = "512Mi"
+	cfg.flags.ImagePullSecrets = []string{"regcred"}
 
 	executor, err := newKubeExecutor(
 		logr.Discard(),
@@ -122,6 +151,7 @@ func TestKubeExecutor_SpawnOperation(t *testing.T) {
 	}
 	assert.Equal(t, wantLabels, jobsClient.job.Labels)
 	assert.Equal(t, wantLabels, secretsClient.secret.Labels)
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "regcred"}}, jobsClient.job.Spec.Template.Spec.ImagePullSecrets)
 	assert.Equal(t, map[string]string{"jobToken": "token"}, secretsClient.secret.StringData)
 }
 


### PR DESCRIPTION
Custom job image support didn't support private registry unless patching the service account with pull secrets.

This PR adds support for configuring pull secrets for kubernetes executor job image. Secrets are configured separately from the main otfd/otfd-agent pull secrets.