### PR TITLE
feat: Implement a retry mechanism for kubernetes job spawning

### DIFF
--- a/internal/runner/executor_kube.go
+++ b/internal/runner/executor_kube.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/leg100/otf/internal"
 	"github.com/leg100/otf/internal/logr"
 	"github.com/leg100/otf/internal/resource"
@@ -18,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -60,6 +62,8 @@ func init() {
 		),
 		// Delete job by default 1 hour after it has finished
 		TTLAfterFinish: time.Hour,
+		// Retry spawning a job this many times.
+		SpawnRetries: 3,
 		flags: kubeConfigFlags{
 			RequestCPU:    "500m",
 			RequestMemory: "128Mi",
@@ -72,7 +76,6 @@ var (
 	defaultKubeConfig kubeConfig
 )
 
-
 type kubeConfig struct {
 	Namespace      string
 	Image          string
@@ -81,6 +84,7 @@ type kubeConfig struct {
 	ServiceAccount string
 	CachePVC       string
 	TTLAfterFinish time.Duration
+	SpawnRetries   int
 
 	requestCPU    k8sresource.Quantity
 	requestMemory k8sresource.Quantity
@@ -104,6 +108,7 @@ type kubeConfigFlags struct {
 func registerKubeFlags(flags *pflag.FlagSet, cfg *kubeConfig) {
 	flags.StringVar(&cfg.Image, "kubernetes-job-image", cfg.Image, "Image to use for kubernetes jobs.")
 	flags.DurationVar(&cfg.TTLAfterFinish, "kubernetes-ttl-after-finish", cfg.TTLAfterFinish, "Delete finished kubernetes job after this duration.")
+	flags.IntVar(&cfg.SpawnRetries, "kubernetes-spawn-retries", cfg.SpawnRetries, "Number of times to retry spawning a kubernetes job before reporting the job as errored. A retry resumes from the first step that has not yet completed. Zero disables retrying.")
 	flags.StringVar(&cfg.flags.RequestCPU, "kubernetes-request-cpu", cfg.flags.RequestCPU, "Requested CPU for kubernetes job.")
 	flags.StringVar(&cfg.flags.RequestMemory, "kubernetes-request-memory", cfg.flags.RequestMemory, "Requested memory for kubernetes job.")
 	flags.StringVar(&cfg.flags.LimitCPU, "kubernetes-limit-cpu", cfg.flags.LimitCPU, "CPU limit for kubernetes job.")
@@ -121,6 +126,7 @@ type kubeExecutor struct {
 
 type kubeExecutorJobsClient interface {
 	Create(ctx context.Context, job *batchv1.Job, opts metav1.CreateOptions) (*batchv1.Job, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*batchv1.Job, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*batchv1.JobList, error)
 }
 
@@ -168,6 +174,10 @@ func newKubeExecutor(
 		executor.Config.limitMemory = &limitMemory
 	}
 
+	if kubeConfig.SpawnRetries < 0 {
+		return nil, fmt.Errorf("invalid spawn retries: must not be negative: %d", kubeConfig.SpawnRetries)
+	}
+
 	executor.Config.labels = make(map[string]string)
 	for _, label := range kubeConfig.flags.Labels {
 		k, v, ok := strings.Cut(label, "=")
@@ -194,6 +204,122 @@ func newKubeExecutor(
 	executor.jobs = clientset.BatchV1().Jobs(kubeConfig.Namespace)
 
 	return executor, nil
+}
+
+// optionalStepError wraps an error from a spawn step that the kubernetes job
+// does not depend upon. Such a step is retried like any other, but if the
+// retries are exhausted the spawn as a whole must still be reported as having
+// succeeded, because the job is running.
+type optionalStepError struct{ err error }
+
+func (e *optionalStepError) Error() string { return e.err.Error() }
+func (e *optionalStepError) Unwrap() error { return e.err }
+
+// spawn is an attempt-in-progress at spawning a kubernetes job for an OTF job.
+// Its specs are built once and then held fixed - in particular the generated
+// name, so that a retry addresses the same objects rather than creating a second
+// secret and a second kubernetes job, which would carry out the OTF job twice
+// concurrently. The remaining fields record progress, so that a retry resumes
+// from the first step that has not yet completed.
+type spawn struct {
+	job    *Job
+	name   string
+	secret *corev1.Secret
+	spec   *batchv1.Job
+
+	secretCreated bool
+	jobCreated    bool
+	kjob          *batchv1.Job // nil until the created job's UID is known
+	ownerRefSet   bool
+}
+
+// retry invokes fn, retrying with exponential backoff up to SpawnRetries times
+// before returning the last error.
+func (s *kubeExecutor) retry(ctx context.Context, sp *spawn, fn func() error) error {
+	if s.Config.SpawnRetries <= 0 {
+		// Retrying is disabled: make a single attempt. NOTE: this must be
+		// handled explicitly because backoff.WithMaxRetries treats a maximum of
+		// zero as unlimited.
+		return fn()
+	}
+	policy := backoff.NewExponentialBackOff()
+	policy.InitialInterval = 500 * time.Millisecond
+	policy.MaxInterval = 5 * time.Second
+	// Bound the retries solely by their number, not by elapsed time: an attempt
+	// can itself block for the duration of the API server's etcd request
+	// timeout, which would make the effective number of attempts unpredictable.
+	policy.MaxElapsedTime = 0
+
+	tries := backoff.WithMaxRetries(policy, uint64(s.Config.SpawnRetries))
+	return backoff.RetryNotify(
+		fn,
+		backoff.WithContext(tries, ctx),
+		func(err error, next time.Duration) {
+			s.Logger.Error(err, "retrying spawn of kubernetes job", "name", sp.name, "otf-job", sp.job, "backoff", next)
+		},
+	)
+}
+
+// spawn makes the kubernetes API calls needed to spawn a job, resuming from the
+// first step that has not yet completed.
+// Steps that the kubernetes job does not depend upon return an optionalStepError.
+func (s *kubeExecutor) spawn(ctx context.Context, sp *spawn) error {
+	if !sp.secretCreated {
+		_, err := s.secrets.Create(ctx, sp.secret, metav1.CreateOptions{})
+		switch {
+		case apierrors.IsAlreadyExists(err):
+			// An earlier attempt timed out but did in fact create the secret.
+		case err != nil:
+			return fmt.Errorf("creating kubernetes secret for job token: %w", err)
+		}
+		sp.secretCreated = true
+		s.Logger.V(4).Info("created kubernetes secret for job token", "name", sp.name, "namespace", s.Config.Namespace, "otf-job", sp.job)
+	}
+
+	if !sp.jobCreated {
+		kjob, err := s.jobs.Create(ctx, sp.spec, metav1.CreateOptions{})
+		switch {
+		case apierrors.IsAlreadyExists(err):
+			// Earlier attempt created the job; UID is unknown and to be retrieved below.
+		case err != nil:
+			return fmt.Errorf("creating kubernetes job: %w", err)
+		default:
+			sp.kjob = kjob
+		}
+		sp.jobCreated = true
+		s.Logger.V(1).Info("created kubernetes job", "name", sp.name, "namespace", s.Config.Namespace, "otf-job", sp.job)
+	}
+
+	// The kubernetes job now exists and is going to run to completion, so every
+	// remaining step is optional.
+
+	if sp.kjob == nil {
+		// The create response was lost to a timeout. Retrieve the job in order
+		// to obtain the UID needed for the owner reference.
+		kjob, err := s.jobs.Get(ctx, sp.name, metav1.GetOptions{})
+		if err != nil {
+			return &optionalStepError{fmt.Errorf("retrieving kubernetes job created by an earlier attempt: %w", err)}
+		}
+		sp.kjob = kjob
+	}
+
+	if !sp.ownerRefSet {
+		// Set secret's owner to its job, so that it is deleted when its job is deleted.
+		sp.secret.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "batch/v1",
+				Kind:       "job",
+				Name:       sp.kjob.Name,
+				UID:        sp.kjob.UID,
+			},
+		}
+		if _, err := s.secrets.Update(ctx, sp.secret, metav1.UpdateOptions{}); err != nil {
+			return &optionalStepError{fmt.Errorf("setting kubernetes job token secret owner reference: %w", err)}
+		}
+		sp.ownerRefSet = true
+	}
+
+	return nil
 }
 
 func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, job *Job, jobToken []byte) error {
@@ -240,12 +366,6 @@ func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, jo
 			jobTokenSecretKey: string(jobToken),
 		},
 	}
-	ksecret, err := s.secrets.Create(ctx, secret, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("creating kubernetes secret for job token: %w", err)
-	}
-	s.Logger.V(4).Info("created kubernetes secret for job token", "name", ksecret.GetName(), "namespace", ksecret.GetNamespace(), "otf-job", job)
-
 	// Create k8s job for OTF job.
 	spec := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +409,7 @@ func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, jo
 									ValueFrom: &corev1.EnvVarSource{
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: ksecret.GetName(),
+												Name: jobName,
 											},
 											Key: jobTokenSecretKey,
 										},
@@ -365,30 +485,19 @@ func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, jo
 			},
 		}
 	}
-	kjob, err := s.jobs.Create(ctx, spec, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("creating kubernetes job: %w", err)
-	}
-	s.Logger.V(1).Info("created kubernetes job", "name", kjob.GetName(), "namespace", kjob.GetNamespace(), "otf-job", job)
+	// Retry the spawn as a whole rather than each API call individually: an
+	// attempt resumes from the first step that has not yet completed, so a retry
+	// costs no more API calls than retrying that step alone would, but there is
+	// a single budget and a single place where the outcome is decided.
+	sp := &spawn{job: job, name: jobName, secret: secret, spec: spec}
+	err := s.retry(ctx, sp, func() error { return s.spawn(ctx, sp) })
 
-	// Set secret's owner to its job, so that it is deleted when its job is
-	// deleted.
-	secret.OwnerReferences = []metav1.OwnerReference{
-		{
-			// NOTE: the API version and kind are empty strings in the returned
-			// job struct, so we're forced to hardcode them.
-			APIVersion: "batch/v1",
-			Kind:       "job",
-			Name:       kjob.Name,
-			UID:        kjob.UID,
-		},
+	var optional *optionalStepError
+	if errors.As(err, &optional) {
+		s.Logger.Error(optional, "spawned kubernetes job but could not complete an optional step; job token secret will not be garbage collected with its job", "name", jobName, "namespace", s.Config.Namespace, "otf-job", job)
+		return nil
 	}
-	_, err = s.secrets.Update(ctx, secret, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("setting kubernetes job token secret owner reference: %w", err)
-	}
-
-	return nil
+	return err
 }
 
 func (s *kubeExecutor) currentJobs(ctx context.Context, runnerID resource.TfeID) int {

--- a/internal/runner/executor_kube_test.go
+++ b/internal/runner/executor_kube_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/leg100/otf/internal/logr"
@@ -12,7 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestNewKubeExecutor(t *testing.T) {
@@ -125,29 +129,236 @@ func TestKubeExecutor_SpawnOperation(t *testing.T) {
 	assert.Equal(t, map[string]string{"jobToken": "token"}, secretsClient.secret.StringData)
 }
 
+// TestKubeExecutor_SpawnOperation_retry tests the handling of the transient
+// kubernetes API errors that occur when its etcd backend is under load. A job
+// that fails to spawn cannot be spawned later, so a transient error must be
+// retried, and an error arising *after* the kubernetes job has been created must
+// not be reported as a failure to spawn.
+func TestKubeExecutor_SpawnOperation_retry(t *testing.T) {
+	// etcdTimeout is representative of the error the kubernetes API server
+	// returns when its etcd backend cannot commit a write in time.
+	etcdTimeout := errors.New("etcdserver: request timed out")
+
+	newExecutor := func(t *testing.T, retries int) (*kubeExecutor, *fakeSecretsClient, *fakeJobsClient) {
+		t.Helper()
+		cfg := defaultKubeConfig
+		cfg.SpawnRetries = retries
+		executor, err := newKubeExecutor(logr.Discard(), defaultOperationConfig(), cfg)
+		require.NoError(t, err)
+		secrets := &fakeSecretsClient{}
+		jobs := &fakeJobsClient{}
+		executor.secrets = secrets
+		executor.jobs = jobs
+		return executor, secrets, jobs
+	}
+	newTestJob := func(t *testing.T) *Job {
+		t.Helper()
+		return &Job{
+			ID:           resource.NewTfeID(resource.JobKind),
+			RunID:        resource.NewTfeID(resource.RunKind),
+			Phase:        run.PlanPhase,
+			Status:       JobAllocated,
+			Organization: organization.NewTestName(t),
+			WorkspaceID:  resource.NewTfeID(resource.WorkspaceKind),
+			RunnerID:     new(resource.NewTfeID(resource.RunnerKind)),
+		}
+	}
+
+	t.Run("retries transient secret create error", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		secrets.createErrs = []error{etcdTimeout, etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 3, secrets.creates, "should have created secret on third attempt")
+		assert.Equal(t, 1, jobs.creates, "should have created job once")
+	})
+
+	t.Run("retries transient job create error", func(t *testing.T) {
+		executor, _, jobs := newExecutor(t, 3)
+		jobs.createErrs = []error{etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, jobs.creates, "should have created job on second attempt")
+	})
+
+	t.Run("gives up after exhausting retries", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 1)
+		secrets.createErrs = []error{etcdTimeout, etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, etcdTimeout)
+		assert.Equal(t, 2, secrets.creates, "should have made one attempt plus one retry")
+		assert.Zero(t, jobs.creates, "should not have created job")
+	})
+
+	t.Run("makes single attempt when retrying is disabled", func(t *testing.T) {
+		executor, secrets, _ := newExecutor(t, 0)
+		secrets.createErrs = []error{etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.Error(t, err)
+		assert.Equal(t, 1, secrets.creates)
+	})
+
+	t.Run("tolerates secret already existing", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		// An earlier attempt timed out but did in fact create the secret.
+		secrets.createErrs = []error{apierrors.NewAlreadyExists(schema.GroupResource{Resource: "secrets"}, "job-abc")}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, secrets.creates, "should not have retried")
+		assert.Equal(t, 1, jobs.creates, "should have proceeded to create job")
+	})
+
+	t.Run("tolerates job already existing", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		jobs.createErrs = []error{apierrors.NewAlreadyExists(schema.GroupResource{Resource: "jobs"}, "job-abc")}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, jobs.creates, "should not have retried")
+		// The create response was lost, so the job is fetched to recover the UID
+		// needed for the owner reference.
+		assert.Equal(t, 1, jobs.gets, "should have fetched the existing job")
+		assert.Equal(t, 1, secrets.creates, "should not have re-created the secret")
+		require.Len(t, secrets.secret.OwnerReferences, 1)
+		assert.Equal(t, types.UID("fake-uid"), secrets.secret.OwnerReferences[0].UID)
+	})
+
+	t.Run("owner reference is skipped if existing job cannot be fetched", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		jobs.createErrs = []error{apierrors.NewAlreadyExists(schema.GroupResource{Resource: "jobs"}, "job-abc")}
+		jobs.getErrs = []error{etcdTimeout, etcdTimeout, etcdTimeout, etcdTimeout}
+
+		// The job is running regardless, so this must not fail the spawn.
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 4, jobs.gets, "should have retried on the shared spawn budget")
+		assert.Equal(t, 1, secrets.creates, "completed steps should not be repeated")
+		assert.Equal(t, 1, jobs.creates, "completed steps should not be repeated")
+		assert.Zero(t, secrets.updates, "should not have attempted to set owner reference")
+	})
+
+	t.Run("retries transient owner reference error", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		secrets.updateErrs = []error{etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, secrets.updates, "should have set owner reference on second attempt")
+		assert.NotEmpty(t, secrets.secret.OwnerReferences, "secret should not be left orphaned")
+		assert.Equal(t, 1, secrets.creates, "should not have re-created the secret")
+		assert.Equal(t, 1, jobs.creates, "should not have re-created the job")
+	})
+
+	t.Run("owner reference failure does not fail the spawn", func(t *testing.T) {
+		executor, secrets, jobs := newExecutor(t, 3)
+		secrets.updateErrs = []error{etcdTimeout, etcdTimeout, etcdTimeout, etcdTimeout}
+
+		// The kubernetes job has been created and is going to run, so the job
+		// must not be reported as having failed to spawn - the secret is leaked
+		// instead, which is by far the lesser evil.
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 4, secrets.updates, "should have retried on the shared spawn budget")
+		assert.Equal(t, 1, secrets.creates, "completed steps should not be repeated")
+		assert.Equal(t, 1, jobs.creates, "completed steps should not be repeated")
+	})
+
+	t.Run("owner reference is not retried when retrying is disabled", func(t *testing.T) {
+		executor, secrets, _ := newExecutor(t, 0)
+		secrets.updateErrs = []error{etcdTimeout}
+
+		err := executor.SpawnOperation(t.Context(), nil, newTestJob(t), []byte("token"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, secrets.updates)
+	})
+}
+
 type fakeSecretsClient struct {
 	secret *corev1.Secret
+	// createErrs are returned by successive calls to Create; a nil entry, or
+	// exhausting the slice, means the call succeeds.
+	createErrs []error
+	creates    int
+	// updateErrs are returned by successive calls to Update; a nil entry, or
+	// exhausting the slice, means the call succeeds.
+	updateErrs []error
+	updates    int
 }
 
 func (f *fakeSecretsClient) Create(ctx context.Context, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {
+	f.creates++
+	if len(f.createErrs) > 0 {
+		err := f.createErrs[0]
+		f.createErrs = f.createErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	f.secret = secret
 	return secret, nil
 }
 
 func (f *fakeSecretsClient) Update(ctx context.Context, secret *corev1.Secret, opts metav1.UpdateOptions) (*corev1.Secret, error) {
+	f.updates++
+	if len(f.updateErrs) > 0 {
+		err := f.updateErrs[0]
+		f.updateErrs = f.updateErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	f.secret = secret
 	return secret, nil
 }
 
 type fakeJobsClient struct {
 	job *batchv1.Job
+	// createErrs are returned by successive calls to Create; a nil entry, or
+	// exhausting the slice, means the call succeeds.
+	createErrs []error
+	creates    int
+	// getErrs are returned by successive calls to Get; a nil entry, or
+	// exhausting the slice, means the call succeeds.
+	getErrs []error
+	gets    int
+}
+
+func (f *fakeJobsClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*batchv1.Job, error) {
+	f.gets++
+	if len(f.getErrs) > 0 {
+		err := f.getErrs[0]
+		f.getErrs = f.getErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: "fake-uid"},
+	}, nil
 }
 
 func (f *fakeJobsClient) Create(ctx context.Context, job *batchv1.Job, opts metav1.CreateOptions) (*batchv1.Job, error) {
+	f.creates++
+	if len(f.createErrs) > 0 {
+		err := f.createErrs[0]
+		f.createErrs = f.createErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	f.job = job
 	return job, nil
 }
 
 func (f *fakeJobsClient) List(ctx context.Context, opts metav1.ListOptions) (*batchv1.JobList, error) {
+	if f.job == nil {
+		return &batchv1.JobList{}, nil
+	}
 	return &batchv1.JobList{Items: []batchv1.Job{*f.job}}, nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -27,9 +27,10 @@ type Runner struct {
 	PluginCache     bool   // toggle use of terraform's shared plugin cache
 	TerraformBinDir string // destination directory for terraform binaries
 
-	runners    runnerClient
-	executor   executor
-	registered chan struct{}
+	runners                runnerClient
+	executor               executor
+	operationClientCreator OperationClientCreator
+	registered             chan struct{}
 
 	logger logr.Logger // logger that logs messages regardless of whether runner is a server or agent runner.
 	v      int         // logger verbosity
@@ -55,9 +56,10 @@ func New(
 			MaxJobs:      cfg.MaxJobs,
 			ExecutorKind: cfg.ExecutorKind,
 		},
-		runners:    runnerClient,
-		registered: make(chan struct{}),
-		logger:     logger,
+		runners:                runnerClient,
+		operationClientCreator: operationClientCreator,
+		registered:             make(chan struct{}),
+		logger:                 logger,
 	}
 	if !cfg.IsAgent {
 		// Set a higher threshold for logging on server runner where the runner is
@@ -164,6 +166,12 @@ func (r *Runner) Start(ctx context.Context) error {
 						return fmt.Errorf("starting job and retrieving job token: %w", err)
 					}
 					if err := r.executor.SpawnOperation(ctx, g, j, token); err != nil {
+						// The job has already been started, so it is skipped by
+						// subsequent passes over allocated jobs and can never be
+						// spawned again. Report it as errored, otherwise it
+						// remains in the running state and its run hangs until
+						// its phase timeout expires.
+						r.failJob(ctx, j, token, err)
 						return fmt.Errorf("spawning job operation: %w", err)
 					}
 				}
@@ -184,6 +192,27 @@ func (r *Runner) Start(ctx context.Context) error {
 
 func (r *Runner) Started() <-chan struct{} {
 	return r.registered
+}
+
+// Report a job as failed.
+func (r *Runner) failJob(ctx context.Context, job *Job, jobToken []byte, cause error) {
+	// Report the job using a context that is still valid for a further 10
+	// seconds unless daemon is forcefully shutdown.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	// Authenticate as the job.
+	ctx = authz.AddSubjectToContext(ctx, job)
+
+	client := r.operationClientCreator(string(jobToken))
+	err := client.FinishJob(ctx, job.ID, FinishJobOptions{
+		Status: JobErrored,
+		Error:  cause.Error(),
+	})
+	if err != nil {
+		r.logger.Error(err, "reporting job as errored after failing to spawn operation", "job", job)
+		return
+	}
+	r.logger.V(r.v).Info("reported job as errored after failing to spawn operation", "job", job)
 }
 
 func (r *Runner) sendStatusUpdates(ctx context.Context) error {


### PR DESCRIPTION
This PR adds a retry mechanism to the kubernetes executor spawn operation to mitigate hung runs caused by API rejection on busy clusters. Issue surfaced through testing large volume of concurrent runs causing etcd instability. While there are cluster measures to be taken to help boost etcd performance, it is out of scope and this PR focuses on implementing recoverability.

## Problem

With the kubernetes executor, two bugs cause a run to hang in `planning` or `applying` with no pod, no log output and no error surfaced in the UI until its phase timeout expires. On a busy deployment this is invisible as the run sits there with no indication of why and just shows an active phase with no log output.

Both bugs are triggered by rejection from the Kubernetes API server. The issue surfaced as `etcdserver: request timed out` while running 100s of concurrent runs. The issue isn't that the API server occasionally rejects a write which is normal and recoverable, it's that OTF turns the recoverable rejection into a stranded run.

### Bug 1: job is marked running before its pod exists

In the `Runner.Start` process jobs loop:

```go
token, err := r.runners.StartJob(ctx, j.ID)   // job -> running, run -> planning/applying
...
if err := r.executor.SpawnOperation(ctx, g, j, token); err != nil {
    return fmt.Errorf("spawning job operation: %w", err)
}
```

`StartJob` commits the state transition *before* the pod is created. When `SpawnOperation` then fails, `processJobs` returns an error and the `backoff.RetryNotify` wrapper retries it but the job is now `JobRunning`, so the next line of the loop skips it forever:

```go
for _, j := range jobs {
    if j.Status != JobAllocated {
        continue    // the failed job is never retried
    }
```

The allocator can't help either: it only reallocates jobs in `JobAllocated`, so nothing in the system ever touches that job again. It stays `running` with no corresponding Kubernetes Job, and its run hangs until `PlanningTimeout` / `ApplyingTimeout`.

The OTFD logs are the clearest way to see it. A healthy spawn produces five lines:

```
allocated job     ... phase=plan
received job
started plan
created kubernetes secret for job token
created kubernetes job
```

A failed one produces three, then nothing until the phase timeout fires:

```
allocated job     ... phase=apply
received job
started apply
                  <- no secret, no kubernetes job, ever
ERROR processing jobs  error="spawning job operation: creating kubernetes secret
                              for job token: etcdserver: request timed out"
...some time later...
canceled job      ... status=canceled
```

### Bug 2: setting the job token secret's owner reference is fatal

`SpawnOperation` makes three sequential API calls:

| # | Call | On failure today |
|---|---|---|
| 1 | `secrets.Create` | fatal - correct, nothing was created |
| 2 | `jobs.Create` | fatal - correct, no pod will run |
| 3 | `secrets.Update` (owner reference) | **fatal - incorrect** |

By the time (3) runs, the kubernetes Job has already been created and its pod is going to run to completion. Returning an error there reports a job as having failed to spawn when it has in fact spawned and via Bug 1 that strands the run, for a job that is working as expected. The only real consequence of a missing owner reference is that the secret isn't garbage collected along with its job.

## Fix

### 1. Retry the spawn

`SpawnOperation` now retries the whole spawn rather than each call individually. The new `spawn` struct records which steps have completed, so a retry resumes from the first incomplete one and issues exactly one API call, the one that failed rather than repeating work:

```go
if !sp.secretCreated { ... }
if !sp.jobCreated    { ... }
// The kubernetes job now exists and is going to run to completion, so every
// remaining step is optional.
if sp.kjob == nil    { ... }   // recover the UID after a lost create response
if !sp.ownerRefSet   { ... }
```

`AlreadyExists` is treated as success, which is what makes the resume correct. `etcdserver: request timed out` is *ambiguous*, the write may have committed and only the response was lost so without this, retrying would convert a successful write into a hard failure.

### 2. An owner-reference failure no longer fails the spawn

Steps reached after the Job exists return an `optionalStepError`. They're retried like anything else, but if the budget is exhausted `SpawnOperation` returns `nil`, because the pod is running:

```go
var optional *optionalStepError
if errors.As(err, &optional) {
    s.Logger.Error(optional, "spawned kubernetes job but could not complete an optional step; ...")
    return nil
}
return err
```

As previously mentioned, the only real consequence of a missing owner reference is that the secret isn't garbage collected along with its job.

### 3. Report the job errored when the spawn ultimately fails

When retries are exhausted, `Runner.failJob` reports the job as `JobErrored`, which errors its run phase. The run fails visibly with the API error attached, and is immediately re-runnable, instead of hanging for the phase timeout.

This needed no new service method, API endpoint, or state transition. `Service.FinishJob` only accepts the job itself as caller, and `StartJob` has already returned the job's token, so `failJob` builds a client via the existing `operationClientCreator`, the same mechanism `DoOperation` uses.