### PR TITLE
feat: Support concurrency configuration for kubernetes executor

### DIFF
--- a/docs/docs/config/flags.md
+++ b/docs/docs/config/flags.md
@@ -26,9 +26,13 @@ Sets the amount of time a run is permitted to be in the `applying` state before 
 ## `--concurrency`
 
 * System: `otfd`, `otf-agent`
-* Default: 5
+* Default: 5 for the [fork](executors.md#fork) executor; unlimited for the [kubernetes](executors.md#kubernetes) executor
 
-Sets the number of workers that can process runs concurrently. Only applies to the [fork](#-executor) executor.
+Sets the number of runs that can be processed concurrently. Runs beyond the limit remain queued until a running job completes.
+
+For the [fork](executors.md#fork) executor this is the number of workers, and therefore the number of forked processes. For the [kubernetes](executors.md#kubernetes) executor it is the number of kubernetes jobs permitted to exist at any one time.
+
+Specify `0` for an unlimited number of concurrent runs. The [fork](executors.md#fork) executor does not permit `0`.
 
 ## `--default-engine`
 

--- a/docs/docs/executors.md
+++ b/docs/docs/executors.md
@@ -23,6 +23,8 @@ The kubernetes executor executes jobs on kubernetes. Each job is run as a [kuber
 
 This executor is only functional when `otfd` or `otf-agent` is deployed via the [helm charts](https://github.com/leg100/otf/tree/master/charts) to a kubernetes cluster.
 
+By default an unlimited number of kubernetes jobs can be created. Set the [--concurrency](config/flags.md#-concurrency) flag to limit the number of kubernetes jobs that can exist at any one time.
+
 There are a number of flags that customise the jobs:
 
 * [`--kubernetes-job-image`](config/flags.md#-kubernetes-job-image)

--- a/internal/runner/allocator.go
+++ b/internal/runner/allocator.go
@@ -215,11 +215,11 @@ func (a *allocator) allocate(ctx context.Context, job *Job) error {
 		if runner.AgentPool != nil && job.AgentPoolID != nil && runner.AgentPool.ID != *job.AgentPoolID {
 			continue
 		}
-		// skip runners with insufficient capacity (only applicable to runners
-		// with a 'fork' executor kind - an infinite number of jobs can be
-		// allocated to the 'kubernetes' executor kind, where kubernetes itself
-		// is then responsible for allocation of resources.
-		if runner.ExecutorKind == ForkExecutorKind && runner.MaxJobs == a.currentJobs[runner.ID] {
+		// Skip runners with insufficient capacity.
+		// A runner with a limit of zero is unlimited and never has insufficient
+		// capacity (only applicable to runners with a 'kubernetes' executor kind),
+		// where kubernetes itself is then responsible for allocation of resources.
+		if runner.MaxJobs > 0 && a.currentJobs[runner.ID] >= runner.MaxJobs {
 			insufficientCapacity = true
 			continue
 		}

--- a/internal/runner/allocator_test.go
+++ b/internal/runner/allocator_test.go
@@ -151,6 +151,43 @@ func TestAllocator_allocate(t *testing.T) {
 			},
 		},
 		{
+			name: "do not allocate job to kubernetes runner with insufficient capacity",
+			runners: []*RunnerMeta{
+				{ID: runner1ID, Status: RunnerIdle, CurrentJobs: 100, MaxJobs: 100, ExecutorKind: KubeExecutorKind},
+			},
+			job: &Job{
+				ID:     job1ID,
+				Status: JobUnallocated,
+			},
+			wantJob: &Job{
+				ID:     job1ID,
+				Status: JobUnallocated,
+			},
+			wantRunners: map[resource.TfeID]*RunnerMeta{
+				runner1ID: {ID: runner1ID, Status: RunnerIdle, CurrentJobs: 100, MaxJobs: 100, ExecutorKind: KubeExecutorKind},
+			},
+			wantCurrentJobs: map[resource.TfeID]int{runner1ID: 100},
+		},
+		{
+			name: "allocate job to kubernetes runner with unlimited capacity",
+			runners: []*RunnerMeta{
+				{ID: runner1ID, Status: RunnerIdle, CurrentJobs: 100, MaxJobs: 0, ExecutorKind: KubeExecutorKind},
+			},
+			job: &Job{
+				ID:     job1ID,
+				Status: JobUnallocated,
+			},
+			wantJob: &Job{
+				ID:       job1ID,
+				Status:   JobAllocated,
+				RunnerID: &runner1ID,
+			},
+			wantRunners: map[resource.TfeID]*RunnerMeta{
+				runner1ID: {ID: runner1ID, Status: RunnerIdle, CurrentJobs: 100, MaxJobs: 0, ExecutorKind: KubeExecutorKind},
+			},
+			wantCurrentJobs: map[resource.TfeID]int{runner1ID: 101},
+		},
+		{
 			name: "re-allocate job from unresponsive agent",
 			runners: []*RunnerMeta{
 				{ID: runner1ID, Status: RunnerUnknown},
@@ -213,6 +250,11 @@ func TestAllocator_allocate(t *testing.T) {
 			// check job
 			if tt.wantJob != nil {
 				assert.Equal(t, tt.wantJob, a.jobs[tt.wantJob.ID])
+			}
+			// check tally of current jobs, which determines whether a runner
+			// has capacity for further jobs.
+			for id, want := range tt.wantCurrentJobs {
+				assert.Equal(t, want, a.currentJobs[id])
 			}
 		})
 	}

--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -1,6 +1,9 @@
 package runner
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/spf13/pflag"
 )
 
@@ -8,22 +11,61 @@ type Config struct {
 	OperationConfig
 
 	Name         string       // descriptive name given to runner
-	MaxJobs      int          // number of jobs the runner can execute at any one time. Only applicable to the 'fork' excecutor.
+	MaxJobs      *int         // number of jobs the runner can execute at any one time.
 	ExecutorKind ExecutorKind // how jobs are launched: forked processes or kubernetes jobs
 	KubeConfig   kubeConfig
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		MaxJobs:         DefaultMaxJobs,
 		ExecutorKind:    ForkExecutorKind,
 		KubeConfig:      defaultKubeConfig,
 		OperationConfig: defaultOperationConfig(),
 	}
 }
 
+func (c *Config) resolveMaxJobs() (int, error) {
+	if c.MaxJobs == nil {
+		if c.ExecutorKind == ForkExecutorKind {
+			return DefaultMaxJobs, nil
+		}
+		// Unlimited.
+		return 0, nil
+	}
+	switch {
+	case *c.MaxJobs < 0:
+		return 0, fmt.Errorf("concurrency must not be negative: %d", *c.MaxJobs)
+	case *c.MaxJobs == 0 && c.ExecutorKind == ForkExecutorKind:
+		// Forking an unlimited number of processes would exhaust the host.
+		return 0, fmt.Errorf("concurrency must be at least 1 for the %s executor", ForkExecutorKind)
+	}
+	return *c.MaxJobs, nil
+}
+
+type ConcurrencyValue struct{ p **int }
+
+var _ pflag.Value = ConcurrencyValue{}
+
+func (ConcurrencyValue) Type() string { return "int" }
+
+func (c ConcurrencyValue) String() string {
+	if c.p == nil || *c.p == nil {
+		return ""
+	}
+	return strconv.Itoa(**c.p)
+}
+
+func (c ConcurrencyValue) Set(s string) error {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+	*c.p = &n
+	return nil
+}
+
 func RegisterFlags(flags *pflag.FlagSet, cfg *Config) {
-	flags.IntVar(&cfg.MaxJobs, "concurrency", cfg.MaxJobs, "Number of runs that can be processed concurrently. Only applicable to the fork executor.")
+	flags.Var(ConcurrencyValue{p: &cfg.MaxJobs}, "concurrency", fmt.Sprintf("Number of runs that can be processed concurrently. Defaults to %d for the %s executor, and to unlimited (0) for the %s executor.", DefaultMaxJobs, ForkExecutorKind, KubeExecutorKind))
 	flags.Var(&cfg.ExecutorKind, "executor", "Executor for executing jobs: 'fork' or 'kubernetes'")
 	RegisterOperationFlags(flags, &cfg.OperationConfig)
 	registerKubeFlags(flags, &cfg.KubeConfig)

--- a/internal/runner/meta.go
+++ b/internal/runner/meta.go
@@ -20,8 +20,9 @@ type RunnerMeta struct {
 	Version string `jsonapi:"attribute" json:"version"`
 	// Current status of runner
 	Status RunnerStatus `jsonapi:"attribute" json:"status"`
-	// Max number of jobs runner can execute. Only applicable to the 'fork'
-	// executor.
+	// Max number of jobs runner can execute. Zero means the runner can be
+	// allocated an unlimited number of jobs, which only the 'kubernetes'
+	// executor permits.
 	MaxJobs int `jsonapi:"attribute" json:"max_jobs" db:"max_jobs"`
 	// Current number of jobs allocated to runner.
 	CurrentJobs int `jsonapi:"attribute" json:"current_jobs" db:"current_jobs"`

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -49,10 +49,14 @@ func New(
 	operationClientCreator OperationClientCreator,
 	cfg *Config,
 ) (*Runner, error) {
+	maxJobs, err := cfg.resolveMaxJobs()
+	if err != nil {
+		return nil, err
+	}
 	r := &Runner{
 		RunnerMeta: &RunnerMeta{
 			Name:         cfg.Name,
-			MaxJobs:      cfg.MaxJobs,
+			MaxJobs:      maxJobs,
 			ExecutorKind: cfg.ExecutorKind,
 		},
 		runners:    runnerClient,

--- a/internal/runner/ui/templates.templ
+++ b/internal/runner/ui/templates.templ
@@ -85,7 +85,7 @@ templ (t runnersTable) Row(runner *runnerpkg.RunnerMeta) {
 			</span>
 		</td>
 		<td>
-			if runner.ExecutorKind == runnerpkg.ForkExecutorKind {
+			if runner.MaxJobs > 0 {
 				{ fmt.Sprintf("(%d/%d)", runner.CurrentJobs, runner.MaxJobs) }
 			} else {
 				{ runner.CurrentJobs }

--- a/internal/runner/ui/templates_templ.go
+++ b/internal/runner/ui/templates_templ.go
@@ -258,7 +258,7 @@ func (t runnersTable) Row(runner *runnerpkg.RunnerMeta) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if runner.ExecutorKind == runnerpkg.ForkExecutorKind {
+		if runner.MaxJobs > 0 {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("(%d/%d)", runner.CurrentJobs, runner.MaxJobs))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
When using Kubernetes executor either through otfd or otf-agent an unlimited number of jobs can be created and scheduled leading to all cluster resources being consumed and jobs rejected. While resource quotas can be applied to limit the allowed pool, that will just start rejecting jobs sooner.

By supporting the concurrency configuration we can utilize the existing queue used with fork executor and apply our own limits within the application. This allows the administrator to have known restrictions with a maximum workload based on concurrent jobs allowed and job pod resource limits.

Concurrency flag remains backwards compatible leaving fork executor its default of 5 and kubernetes executor unlimited when the flag is unset.