### PR TITLE
feat: New optional --skip-tls-verification flag for agents

### DIFF
--- a/charts/otf-agent/README.md
+++ b/charts/otf-agent/README.md
@@ -76,6 +76,7 @@ address=10.244.0.18 agent.pool_id=apool-5b90443ed82ef769
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | sidecars | list | `[]` | Additional sidecar containers to run alongside the main otf-agent container |
+| skipTLSVerification | bool | `nil` | Skip verification of the OTF server's TLS certificate. Only use with a trusted server when you cannot trust the CA. Inherited by kubernetes jobs. See [docs](https://docs.otf.ninja/config/flags/#-skip-tls-verification). |
 | token | string | `nil` | Token to authenticate the agent. Either this or `tokenFromSecret` must be specified. |
 | tokenFromSecret | object | `nil` | Source token from a secret. Either this or `token` must be specified. |
 | tolerations | list | `[]` |  |

--- a/charts/otf-agent/templates/deployment.yaml
+++ b/charts/otf-agent/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
             {{- end }}
             - name: OTF_URL
               value: "{{ required ".Values.url is required" .Values.url }}"
+            {{- with .Values.skipTLSVerification }}
+            - name: OTF_SKIP_TLS_VERIFICATION
+              value: "{{ . }}"
+            {{- end }}
             {{- with .Values.logging }}
             {{- with .verbosity }}
             - name: OTF_V

--- a/charts/otf-agent/values.yaml
+++ b/charts/otf-agent/values.yaml
@@ -26,6 +26,9 @@ tokenFromSecret:
 # -- (string) URL of the OTF server to connect to. Must begin with `https://` or `http://`. Required.
 url:
 
+# -- (bool) Skip verification of the OTF server's TLS certificate. Only use with a trusted server when you cannot trust the CA. Inherited by kubernetes jobs. See [docs](https://docs.otf.ninja/config/flags/#-skip-tls-verification).
+skipTLSVerification:
+
 logging:
   # -- (int) Logging verbosity, the higher the number the more verbose the logs. See [docs](https://docs.otf.ninja/config/flags/#-v).
   verbosity:

--- a/cmd/otf-agent/main.go
+++ b/cmd/otf-agent/main.go
@@ -74,6 +74,7 @@ func run(ctx context.Context, args []string) error {
 	cmd.Flags().StringVar(&config.Name, "name", "", "Give agent a descriptive name. Optional.")
 	cmd.Flags().StringVar(&url, "url", otfhttp.DefaultURL, "URL of OTF server")
 	cmd.Flags().StringVar(&token, "token", "", "Agent token for authentication")
+	cmd.Flags().BoolVar(&config.SkipTLSVerification, "skip-tls-verification", false, "Skip verification of the OTF server's TLS certificate. When using the kubernetes executor the setting is inherited by jobs.")
 
 	cmd.MarkFlagRequired("token")
 	cmd.SetArgs(args)

--- a/cmd/otf-job/main.go
+++ b/cmd/otf-job/main.go
@@ -55,6 +55,7 @@ func run(ctx context.Context, args []string) error {
 				logger,
 				url,
 				string(jobToken),
+				operationConfig.SkipTLSVerification,
 			)
 			if err != nil {
 				return err
@@ -82,6 +83,7 @@ func run(ctx context.Context, args []string) error {
 	cmd.Flags().StringVar(&jobToken, "job-token", "", "Job token for authentication")
 	cmd.Flags().Var(&jobID, "job-id", "ID of job to execute")
 	cmd.Flags().StringVar(&url, "url", otfhttp.DefaultURL, "URL of OTF server")
+	cmd.Flags().BoolVar(&operationConfig.SkipTLSVerification, "skip-tls-verification", false, "Skip verification of the OTF server's TLS certificate.")
 
 	cmd.SetArgs(args)
 

--- a/docs/docs/config/flags.md
+++ b/docs/docs/config/flags.md
@@ -281,6 +281,19 @@ Hex-encoded 16-byte secret for performing cryptographic work. You should use a c
 !!! note
     The secret is required. It must be exactly 16 bytes in size, and it must be hex-encoded.
 
+## `--skip-tls-verification`
+
+* System: `otf-agent`
+* Default: `false`
+
+Skip verification of the TLS certificate presented by `otfd`. Use this when `otfd` is served with a certificate that the agent cannot verify, e.g. a self-signed certificate, or one issued by an internal certificate authority.
+
+Only enable this for a server you trust when you cannot trust the CA as it disables authentication of the server's identity, leaving the connection open to interception.
+
+When using the `kubernetes` [executor](../executors.md), jobs connect to `otfd` at the same URL as the agent that spawned them, so they inherit this setting; you don't need to configure it separately.
+
+The setting only applies to the connections `otf-agent` and its jobs make to `otfd`.
+
 ## `--site-admins`
 
 * System: `otfd`

--- a/docs/docs/executors.md
+++ b/docs/docs/executors.md
@@ -30,4 +30,6 @@ There are a number of flags that customise the jobs:
 * [`--kubernetes-request-memory`](config/flags.md#-kubernetes-request-memory)
 * [`--kubernetes-ttl-after-finish`](config/flags.md#-kubernetes-ttl-after-finish)
 
+A job connects back to `otfd` at the same URL as the runner that spawned it, so it inherits [`--skip-tls-verification`](config/flags.md#-skip-tls-verification) from that runner rather than being configured separately.
+
 It's advisable to provide a persistent volume for the cache. Otherwise the terraform or tofu binary is downloaded at the beginning of every job. See the helm chart settings to enable the persistent volume claim. You will need to make available a persistent volume that supports the [ReadWriteMany](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) access mode.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -37,12 +37,14 @@ func New(
 	logger logr.Logger,
 	url string,
 	token string,
+	skipTLSVerification bool,
 ) (*Client, error) {
 	httpClient, err := otfhttp.NewClient(otfhttp.ClientConfig{
-		URL:           url,
-		Logger:        logger,
-		Token:         token,
-		RetryRequests: true,
+		URL:                 url,
+		Logger:              logger,
+		Token:               token,
+		RetryRequests:       true,
+		SkipTLSVerification: skipTLSVerification,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -43,6 +43,8 @@ type (
 		RetryRequests bool
 		// Override default http transport
 		Transport http.RoundTripper
+		// Skip verification of the server's TLS certificate.
+		SkipTLSVerification bool
 		// Logger for logging an error upon retry
 		Logger logr.Logger
 	}
@@ -60,7 +62,11 @@ func NewClient(config ClientConfig) (*Client, error) {
 		config.Headers = make(http.Header)
 	}
 	if config.Transport == nil {
-		config.Transport = http.DefaultTransport
+		if config.SkipTLSVerification {
+			config.Transport = InsecureTransport
+		} else {
+			config.Transport = http.DefaultTransport
+		}
 	}
 	config.Headers.Set("User-Agent", "otf-agent")
 

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -50,6 +50,27 @@ func TestClient_UnmarshalResponse(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestNewClient_transport(t *testing.T) {
+	override := &http.Transport{}
+	tests := []struct {
+		name   string
+		config ClientConfig
+		want   http.RoundTripper
+	}{
+		{"verify by default", ClientConfig{}, http.DefaultTransport},
+		{"skip verification", ClientConfig{SkipTLSVerification: true}, InsecureTransport},
+		{"overridden transport takes precedence", ClientConfig{SkipTLSVerification: true, Transport: override}, override},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(tt.config)
+			require.NoError(t, err)
+
+			assert.Same(t, tt.want, client.http.HTTPClient.Transport)
+		})
+	}
+}
+
 func TestClient_checkResponseCode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/integration/organization_token_test.go
+++ b/internal/integration/organization_token_test.go
@@ -29,6 +29,9 @@ func TestIntegration_OrganizationTokens(t *testing.T) {
 		logr.Discard(),
 		daemon.System.URL("/"),
 		string(token),
+		// The daemon's self-signed cert is trusted via SSL_CERT_FILE, so
+		// verification can stay enabled.
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/runner/agent/agent.go
+++ b/internal/runner/agent/agent.go
@@ -14,6 +14,7 @@ func New(logger logr.Logger, serverURL string, token string, config *runner.Conf
 		logger,
 		serverURL,
 		token,
+		config.SkipTLSVerification,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/runner/executor_kube.go
+++ b/internal/runner/executor_kube.go
@@ -319,6 +319,10 @@ func (s *kubeExecutor) SpawnOperation(ctx context.Context, _ *errgroup.Group, jo
 									Name:  "OTF_DEBUG",
 									Value: strconv.FormatBool(s.OperationConfig.Debug),
 								},
+								{
+									Name:  "OTF_SKIP_TLS_VERIFICATION",
+									Value: strconv.FormatBool(s.OperationConfig.SkipTLSVerification),
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/internal/runner/executor_kube_test.go
+++ b/internal/runner/executor_kube_test.go
@@ -125,6 +125,55 @@ func TestKubeExecutor_SpawnOperation(t *testing.T) {
 	assert.Equal(t, map[string]string{"jobToken": "token"}, secretsClient.secret.StringData)
 }
 
+// TestKubeExecutor_SpawnOperation_skipTLSVerification tests that a job inherits
+// the runner's TLS verification setting, because it connects to otfd at the same
+// URL as the runner that spawned it.
+func TestKubeExecutor_SpawnOperation_skipTLSVerification(t *testing.T) {
+	tests := []struct {
+		name string
+		skip bool
+		want string
+	}{
+		{"verify by default", false, "false"},
+		{"skip verification", true, "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opConfig := defaultOperationConfig()
+			opConfig.SkipTLSVerification = tt.skip
+
+			executor, err := newKubeExecutor(
+				logr.Discard(),
+				opConfig,
+				defaultKubeConfig,
+			)
+			require.NoError(t, err)
+
+			jobsClient := &fakeJobsClient{}
+			executor.jobs = jobsClient
+			executor.secrets = &fakeSecretsClient{}
+
+			job := &Job{
+				ID:           resource.NewTfeID(resource.JobKind),
+				RunID:        resource.NewTfeID(resource.RunKind),
+				Phase:        run.PlanPhase,
+				Status:       JobAllocated,
+				Organization: organization.NewTestName(t),
+				WorkspaceID:  resource.NewTfeID(resource.WorkspaceKind),
+				RunnerID:     new(resource.NewTfeID(resource.RunnerKind)),
+			}
+
+			err = executor.SpawnOperation(t.Context(), nil, job, []byte("token"))
+			require.NoError(t, err)
+
+			assert.Contains(t,
+				jobsClient.job.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{Name: "OTF_SKIP_TLS_VERIFICATION", Value: tt.want},
+			)
+		})
+	}
+}
+
 type fakeSecretsClient struct {
 	secret *corev1.Secret
 }

--- a/internal/runner/operation.go
+++ b/internal/runner/operation.go
@@ -95,11 +95,12 @@ type (
 	}
 
 	OperationConfig struct {
-		Debug          bool   // toggle debug mode
-		PluginCache    bool   // toggle use of engine's shared plugin cache
-		PluginCacheDir string // directory for shared plugin cache.
-		EngineBinDir   string // destination directory for engine binaries
-		IsAgent        bool   // set to true if operation is running on an agent
+		Debug               bool   // toggle debug mode
+		PluginCache         bool   // toggle use of engine's shared plugin cache
+		PluginCacheDir      string // directory for shared plugin cache.
+		EngineBinDir        string // destination directory for engine binaries
+		IsAgent             bool   // set to true if operation is running on an agent
+		SkipTLSVerification bool   // skip verification of otfd's TLS certificate.
 	}
 
 	OperationOptions struct {


### PR DESCRIPTION
Running agents against remote OTFD server with self-signed certificate produces TLS verification error.

```
2026-08-10T18:44:23.572222757Z Error: registering runner: Post "https://otf.bby.van.lan/otfapi/agents/register": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

In cases where one does not wish to trust the authority server/cluster wide or override the CA bundle within the images, this exposes a new optional flag to skip TLS verification.

When transport method is not overriden and the flag is set, transport is set to Insecure instead of Default.